### PR TITLE
Implement Phase 2 agent features

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This project provides a command line assistant that interacts with Jira.
 
-Phase 1 implements a basic project scaffold with a minimal REST adapter and a Typer CLI.
+Phase 1 implemented a basic project scaffold with a minimal REST adapter and a Typer CLI.
+
+Phase 2 introduces a simple LangChain agent. The agent wraps the LLM through ``src.llm.llm_wrapper`` and exposes tools for describing, searching and transitioning Jira issues.
 
 ```
 python -m src.cli.main hello

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ openai
 requests
 Typer
 pydantic
+langchain

--- a/src/adapters/jira_api.py
+++ b/src/adapters/jira_api.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 
 import requests
 
@@ -42,4 +42,22 @@ class JiraAPI:
         logger.debug("Transitioning issue %s with payload %s", issue_key, payload)
         resp = self.session.post(url, json=payload)
         resp.raise_for_status()
+
+    def search_issues(self, jql: str) -> List[Dict[str, Any]]:
+        """Return issues matching the JQL query."""
+        url = f"{self.config.base_url}/rest/api/3/search"
+        logger.debug("Searching issues with JQL: %s", jql)
+        resp = self.session.get(url, params={"jql": jql})
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("issues", [])
+
+    def get_transitions(self, issue_key: str) -> List[Dict[str, Any]]:
+        """Fetch available transitions for an issue."""
+        url = f"{self.config.base_url}/rest/api/3/issue/{issue_key}/transitions"
+        logger.debug("Fetching transitions for issue %s", issue_key)
+        resp = self.session.get(url)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("transitions", [])
 

--- a/src/agents/jira_agent.py
+++ b/src/agents/jira_agent.py
@@ -2,9 +2,9 @@
 
 from langchain.agents import Tool
 from langchain.agents import initialize_agent
-from langchain.llms import OpenAI
 
 from adapters.jira_api import JiraAPI, JiraConfig
+from llm.llm_wrapper import get_llm
 import config
 
 jira_client = JiraAPI(JiraConfig(config.JIRA_URL, config.JIRA_USERNAME, config.JIRA_API_TOKEN))
@@ -18,9 +18,22 @@ def describe_issue(issue_key: str) -> str:
     return f"Summary: {summary}\nDescription: {description}"
 
 
+def search_issues(jql: str) -> str:
+    issues = jira_client.search_issues(jql)
+    keys = [issue.get("key") for issue in issues]
+    return ", ".join(keys)
+
+
+def transition_issue(issue_key: str, transition_id: str) -> str:
+    jira_client.transition_issue(issue_key, transition_id)
+    return "Transition performed"
+
+
 def get_agent():
-    llm = OpenAI(api_key=config.OPENAI_API_KEY)
+    llm = get_llm()
     tools = [
-        Tool(name="Describe Issue", func=describe_issue, description="Describe Jira issue")
+        Tool(name="Describe Issue", func=describe_issue, description="Describe Jira issue"),
+        Tool(name="Search Issues", func=search_issues, description="Search issues by JQL"),
+        Tool(name="Transition Issue", func=transition_issue, description="Perform a transition on an issue"),
     ]
     return initialize_agent(tools, llm, agent="zero-shot-react-description", verbose=True)

--- a/src/llm/llm_wrapper.py
+++ b/src/llm/llm_wrapper.py
@@ -1,8 +1,24 @@
-"""Simple wrapper to allow pluggable LLMs."""
+"""Simple wrapper to allow pluggable LLMs used by the agent."""
+
+from typing import Any, Dict
 
 from langchain.llms import OpenAI
+
 import config
 
 
-def get_llm():
-    return OpenAI(api_key=config.OPENAI_API_KEY)
+class LLMWrapper:
+    """Thin wrapper around the LangChain LLM interface."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        params: Dict[str, Any] = {"api_key": config.OPENAI_API_KEY}
+        params.update(kwargs)
+        self.llm = OpenAI(**params)
+
+    def __call__(self, prompt: str) -> str:
+        return self.llm(prompt)
+
+
+def get_llm(**kwargs: Any):
+    """Return the configured LLM instance."""
+    return LLMWrapper(**kwargs)


### PR DESCRIPTION
## Summary
- wrap the LLM in a small `LLMWrapper`
- expose Jira search and transition helpers in `JiraAPI`
- provide LangChain tools for describing, searching and transitioning issues
- reference the wrapper from the agent
- document Phase 2 in README
- include `langchain` in requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m src.cli.main hello` *(fails: ModuleNotFoundError: No module named 'typer')*