### PR TITLE
Add OpenAIService wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Phase 2 introduces a simple LangChain agent. The agent wraps the LLM through ``s
 
 Phase 3 adds a YAML based configuration under ``src/config/criteria.yaml`` and a ``HotReloader`` utility to automatically reload files when they change.
 
+Phase 4 introduces ``OpenAIService`` which loads your API key and model from ``config.py`` and provides a light wrapper around the OpenAI response API used by the agent.
+
 ```
 python -m src.cli.main hello
 ```

--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 """Configuration for Jira AI Assistant."""
 
 OPENAI_API_KEY = "YOUR_OPENAI_API_KEY"
+OPENAI_MODEL = "gpt-3.5-turbo"
 
 JIRA_URL = "https://your-domain.atlassian.net"  # Replace with your Jira site URL
 JIRA_USERNAME = "your.email@example.com"        # Jira username/email

--- a/src/llm/__init__.py
+++ b/src/llm/__init__.py
@@ -1,0 +1,6 @@
+"""LLM helpers for Jira AI Assistant."""
+
+from .openai_service import OpenAIService, get_service
+
+__all__ = ["OpenAIService", "get_service"]
+

--- a/src/llm/llm_wrapper.py
+++ b/src/llm/llm_wrapper.py
@@ -1,22 +1,18 @@
-"""Simple wrapper to allow pluggable LLMs used by the agent."""
+"""Simple wrapper over :class:`OpenAIService` used by the agent."""
 
-from typing import Any, Dict
+from typing import Any
 
-from langchain.llms import OpenAI
-
-import config
+from .openai_service import get_service
 
 
 class LLMWrapper:
-    """Thin wrapper around the LangChain LLM interface."""
+    """Thin wrapper exposing the OpenAI service via a simple ``__call__``."""
 
-    def __init__(self, **kwargs: Any) -> None:
-        params: Dict[str, Any] = {"api_key": config.OPENAI_API_KEY}
-        params.update(kwargs)
-        self.llm = OpenAI(**params)
+    def __init__(self, **_: Any) -> None:
+        self.service = get_service()
 
     def __call__(self, prompt: str) -> str:
-        return self.llm(prompt)
+        return self.service(prompt)
 
 
 def get_llm(**kwargs: Any):

--- a/src/llm/openai_service.py
+++ b/src/llm/openai_service.py
@@ -1,0 +1,33 @@
+import openai
+from typing import Any, Dict, List
+
+import config
+
+
+class OpenAIService:
+    """Service wrapper around the OpenAI API."""
+
+    def __init__(self, model: str | None = None) -> None:
+        openai.api_key = config.OPENAI_API_KEY
+        self.model = model or config.OPENAI_MODEL
+
+    def chat(self, messages: List[Dict[str, str]], **kwargs: Any) -> str:
+        """Send a list of messages to the Chat Completion API."""
+        response = openai.ChatCompletion.create(model=self.model, messages=messages, **kwargs)
+        return response.choices[0].message["content"]
+
+    def __call__(self, prompt: str, **kwargs: Any) -> str:
+        """Call the model with a single prompt string."""
+        return self.chat([{"role": "user", "content": prompt}], **kwargs)
+
+
+_service: OpenAIService | None = None
+
+
+def get_service() -> OpenAIService:
+    """Return a singleton instance of :class:`OpenAIService`."""
+    global _service
+    if _service is None:
+        _service = OpenAIService()
+    return _service
+


### PR DESCRIPTION
## Summary
- add `OPENAI_MODEL` setting
- implement `OpenAIService` to load key and call the Chat Completion API
- adapt `LLMWrapper` to use the new service
- expose service from `llm.__init__`
- document service in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`