### PR TITLE
Add Jira service and interactive main

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,21 @@
-"""Entry point for Jira AI Assistant CLI."""
+"""Simple interactive entry point for Jira AI Assistant."""
 
-from src.cli.main import app
+from src.services import JiraService
+
+
+def main() -> None:
+    issue_key = input("Enter Jira issue key: ").strip()
+    if not issue_key:
+        print("No issue key provided.")
+        return
+
+    service = JiraService()
+    description = service.get_issue_description(issue_key)
+    if description:
+        print(f"Description for {issue_key}:\n{description}")
+    else:
+        print(f"No description found for {issue_key}.")
+
 
 if __name__ == "__main__":
-    app()
+    main()

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,0 +1,5 @@
+"""Service package for Jira AI Assistant."""
+
+from .jira_service import JiraService
+
+__all__ = ["JiraService"]

--- a/src/services/jira_service.py
+++ b/src/services/jira_service.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""Service layer for Jira interactions."""
+
+from typing import Optional, List
+
+from adapters.jira_api import JiraAPI, JiraConfig
+from models.jira_models import Comment, Issue
+import config
+
+
+class JiraService:
+    """High level Jira operations using :class:`JiraAPI`."""
+
+    def __init__(self) -> None:
+        self._api = JiraAPI(
+            JiraConfig(config.JIRA_URL, config.JIRA_USERNAME, config.JIRA_API_TOKEN)
+        )
+
+    def fetch_issue(self, issue_key: str) -> Issue:
+        """Return an :class:`Issue` model populated from Jira."""
+        data = self._api.get_issue(issue_key)
+        fields = data.get("fields", {})
+        comments: List[Comment] = []
+        comment_data = fields.get("comment", {}).get("comments", [])
+        for c in comment_data:
+            author = c.get("author", {}).get("displayName", "")
+            body = c.get("body", "")
+            comments.append(Comment(author=author, body=body))
+
+        return Issue(
+            key=data.get("key", issue_key),
+            summary=fields.get("summary", ""),
+            description=fields.get("description"),
+            comments=comments,
+        )
+
+    def get_issue_description(self, issue_key: str) -> Optional[str]:
+        """Convenience method to return just the issue description."""
+        issue = self.fetch_issue(issue_key)
+        return issue.description


### PR DESCRIPTION
## Summary
- add a `JiraService` for higher-level Jira operations
- expose service from `src.services`
- update main script to ask for an issue key and display the description

## Testing
- `python -m py_compile $(git ls-files '*.py')`