### PR TITLE
Fix Jira API key configuration

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,8 +1,13 @@
 """Configuration for Jira AI Assistant."""
 
-OPENAI_API_KEY = "YOUR_OPENAI_API_KEY"
-OPENAI_MODEL = "gpt-3.5-turbo"
+import os
 
-JIRA_URL = "https://your-domain.atlassian.net"  # Replace with your Jira site URL
-JIRA_USERNAME = "your.email@example.com"        # Jira username/email
-JIRA_API_TOKEN = "YOUR_JIRA_API_TOKEN"          # Jira API token
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "YOUR_OPENAI_API_KEY")
+OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+
+JIRA_URL = os.getenv("JIRA_URL", "https://your-domain.atlassian.net")
+JIRA_USERNAME = os.getenv("JIRA_USERNAME", "your.email@example.com")
+JIRA_API_TOKEN = os.getenv("JIRA_API_TOKEN", "YOUR_JIRA_API_TOKEN")
+
+# Alias for backwards compatibility
+JIRA_API_KEY = JIRA_API_TOKEN

--- a/src/agents/jira_agent.py
+++ b/src/agents/jira_agent.py
@@ -3,7 +3,7 @@
 from langchain.agents import Tool
 from langchain.agents import initialize_agent
 
-from adapters.jira_api import JiraAPI, JiraConfig
+from src.adapters.jira_api import JiraAPI, JiraConfig
 from llm.llm_wrapper import get_llm
 import config
 

--- a/src/services/jira_service.py
+++ b/src/services/jira_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Optional, List
 
-from adapters.jira_api import JiraAPI, JiraConfig
+from src.adapters.jira_api import JiraAPI, JiraConfig
 from models.jira_models import Comment, Issue
 import config
 


### PR DESCRIPTION
## Summary
- load config values from environment variables
- alias `JIRA_API_KEY`
- fix adapter imports

## Testing
- `python main.py` *(fails: No module named 'requests')*
- `pip install openai requests Typer pydantic langchain` *(fails: Could not find a version)*