### PR TITLE
Add logging and switch to OpenAI Responses API

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,25 +1,21 @@
 """Simple interactive entry point for Jira AI Assistant."""
 
-from src.services import JiraService
+import logging
+
+from src.agents.jira_agent import get_agent
 
 
 def main() -> None:
-    issue_key = input("Enter Jira issue key: ").strip()
-    if not issue_key:
-        print("No issue key provided.")
+    logging.basicConfig(level=logging.INFO)
+    question = input("Ask a Jira question: ").strip()
+    if not question:
+        print("No question provided.")
         return
 
-    service = JiraService()
-    try:
-        description = service.get_issue_description(issue_key)
-    except RuntimeError as exc:
-        print(exc)
-        return
-
-    if description:
-        print(f"Description for {issue_key}:\n{description}")
-    else:
-        print(f"No description found for {issue_key}.")
+    agent = get_agent()
+    logging.info("Sending question to agent: %s", question)
+    answer = agent.run(question)
+    print(answer)
 
 
 if __name__ == "__main__":

--- a/src/agents/jira_agent.py
+++ b/src/agents/jira_agent.py
@@ -2,6 +2,9 @@
 
 from langchain.agents import Tool
 from langchain.agents import initialize_agent
+import logging
+
+logger = logging.getLogger(__name__)
 
 from src.adapters.jira_api import JiraAPI, JiraConfig
 from src.llm.llm_wrapper import get_llm
@@ -11,6 +14,7 @@ jira_client = JiraAPI(JiraConfig(config.JIRA_URL, config.JIRA_USERNAME, config.J
 
 
 def describe_issue(issue_key: str) -> str:
+    logger.info("Using Describe Issue on %s", issue_key)
     issue = jira_client.get_issue(issue_key)
     fields = issue.get("fields", {})
     summary = fields.get("summary", "")
@@ -19,12 +23,14 @@ def describe_issue(issue_key: str) -> str:
 
 
 def search_issues(jql: str) -> str:
+    logger.info("Using Search Issues with query: %s", jql)
     issues = jira_client.search_issues(jql)
     keys = [issue.get("key") for issue in issues]
     return ", ".join(keys)
 
 
 def transition_issue(issue_key: str, transition_id: str) -> str:
+    logger.info("Using Transition Issue on %s with transition %s", issue_key, transition_id)
     jira_client.transition_issue(issue_key, transition_id)
     return "Transition performed"
 

--- a/src/llm/openai_service.py
+++ b/src/llm/openai_service.py
@@ -12,9 +12,9 @@ class OpenAIService:
         self.model = model or config.OPENAI_MODEL
 
     def chat(self, messages: List[Dict[str, str]], **kwargs: Any) -> str:
-        """Send a list of messages to the Chat Completion API."""
-        response = openai.ChatCompletion.create(model=self.model, messages=messages, **kwargs)
-        return response.choices[0].message["content"]
+        """Send a list of messages to the OpenAI Responses API."""
+        response = openai.Responses.create(model=self.model, messages=messages, **kwargs)
+        return response["choices"][0]["message"]["content"]
 
     def __call__(self, prompt: str, **kwargs: Any) -> str:
         """Call the model with a single prompt string."""


### PR DESCRIPTION
## Summary
- switch OpenAIService to use the Responses API
- log tool usage inside jira_agent
- update `main.py` to forward questions to the agent and log the interaction

## Testing
- `python -m compileall -q src main.py`
- `python main.py <<'EOF'
What is this jira about?
EOF` *(fails: No module named 'langchain')*