### PR TITLE
Fix LLM wrapper for LangChain agent

### DIFF
--- a/src/llm/llm_wrapper.py
+++ b/src/llm/llm_wrapper.py
@@ -1,20 +1,35 @@
 """Simple wrapper over :class:`OpenAIService` used by the agent."""
 
-from typing import Any
+from typing import Any, List, Optional
+
+from langchain.llms.base import LLM
+from langchain.callbacks.manager import CallbackManagerForLLMRun
 
 from .openai_service import get_service
 
 
-class LLMWrapper:
-    """Thin wrapper exposing the OpenAI service via a simple ``__call__``."""
+class LLMWrapper(LLM):
+    """Thin wrapper exposing the OpenAI service via the LangChain ``LLM`` API."""
 
     def __init__(self, **_: Any) -> None:
+        super().__init__()
         self.service = get_service()
 
-    def __call__(self, prompt: str) -> str:
+    @property
+    def _llm_type(self) -> str:  # pragma: no cover - simple metadata
+        return "openai-wrapper"
+
+    def _call(
+        self,
+        prompt: str,
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> str:
+        """Execute the prompt against the underlying service."""
         return self.service(prompt)
 
 
-def get_llm(**kwargs: Any):
+def get_llm(**kwargs: Any) -> LLMWrapper:
     """Return the configured LLM instance."""
     return LLMWrapper(**kwargs)


### PR DESCRIPTION
## Summary
- implement `LLMWrapper` as a LangChain `LLM`
- expose `_call` via the OpenAI service so LangChain can use it

## Testing
- `python -m py_compile $(git ls-files '*.py')`