### PR TITLE
Fix Pydantic attribute error in LLM wrapper

### DIFF
--- a/src/llm/llm_wrapper.py
+++ b/src/llm/llm_wrapper.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional
 
 from langchain.llms.base import LLM
 from langchain.callbacks.manager import CallbackManagerForLLMRun
+from pydantic import PrivateAttr
 
 from .openai_service import get_service
 
@@ -11,9 +12,11 @@ from .openai_service import get_service
 class LLMWrapper(LLM):
     """Thin wrapper exposing the OpenAI service via the LangChain ``LLM`` API."""
 
-    def __init__(self, **_: Any) -> None:
-        super().__init__()
-        self.service = get_service()
+    _service: Any = PrivateAttr()
+
+    def __init__(self, **data: Any) -> None:
+        super().__init__(**data)
+        self._service = get_service()
 
     @property
     def _llm_type(self) -> str:  # pragma: no cover - simple metadata
@@ -27,7 +30,7 @@ class LLMWrapper(LLM):
         **kwargs: Any,
     ) -> str:
         """Execute the prompt against the underlying service."""
-        return self.service(prompt)
+        return self._service(prompt)
 
 
 def get_llm(**kwargs: Any) -> LLMWrapper:


### PR DESCRIPTION
## Summary
- use `PrivateAttr` on the LLM wrapper so it can hold the OpenAI service instance

## Testing
- `python -m compileall -q src`