### PR TITLE
Add OpenAI configuration and client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copy this file to .env and fill in your OpenAI API key
+OPENAI_API_KEY=
+# Optionally override the default model
+OPENAI_MODEL=

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository contains a minimal Python script that prints `Hello, world!` when executed.
 
+## Configuration
+
+Create a `.env` file based on `.env.example` and provide your OpenAI API key. The default model can be changed in `config.yaml` or by setting `OPENAI_MODEL` in the environment.
+
 ## Usage
 
 Run the script with Python:

--- a/config.py
+++ b/config.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+import os
+import yaml
+from dotenv import load_dotenv
+
+@dataclass
+class Config:
+    openai_api_key: str
+    openai_model: str
+
+
+def load_config(path: str = "config.yaml") -> Config:
+    """Load configuration from YAML file and environment variables."""
+    load_dotenv()
+    data = {}
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    return Config(
+        openai_api_key=os.getenv("OPENAI_API_KEY", data.get("openai_api_key", "")),
+        openai_model=os.getenv("OPENAI_MODEL", data.get("openai_model", "gpt-3.5-turbo")),
+    )

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,1 @@
+openai_model: gpt-3.5-turbo

--- a/openai_client.py
+++ b/openai_client.py
@@ -1,0 +1,20 @@
+import openai
+from typing import List, Dict, Any
+
+from config import load_config
+
+
+class OpenAIClient:
+    """Simple wrapper around the OpenAI SDK."""
+
+    def __init__(self, config_path: str = "config.yaml") -> None:
+        self.config = load_config(config_path)
+        openai.api_key = self.config.openai_api_key
+
+    def chat_completion(self, messages: List[Dict[str, str]], **kwargs: Any) -> Any:
+        """Create a chat completion using the configured model."""
+        return openai.ChatCompletion.create(
+            model=self.config.openai_model,
+            messages=messages,
+            **kwargs,
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,8 @@
-smolagents
-requests
+openai
+python-dotenv
 pytz
 PyYAML
-gradio
-huggingface_hub
-transformers
-torch 
-markdownify
-smolagents==1.13.0
 requests
+smolagents==1.13.0
+gradio
 duckduckgo_search
-pandas


### PR DESCRIPTION
## Summary
- provide `.env.example` and `config.yaml` to store API tokens and LLM model
- implement `config.py` for loading settings from env or config file
- implement a simple `OpenAIClient` wrapper around the OpenAI SDK
- document setup in `README`
- trim requirements list to minimal packages

## Testing
- `python -m py_compile main.py Gradio_UI.py config.py openai_client.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684043fb907c8328adc2bbd5d26c817b