### PR TITLE
Add simple Jira CLI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+JIRA_BASE_URL=https://your-domain.atlassian.net
+JIRA_EMAIL=user@example.com
+JIRA_API_TOKEN=your-api-token

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
-# Hello World
+# Jira AI Assistant
 
-This repository contains a minimal Python script that prints `Hello, world!` when executed.
+This repository contains small utilities for interacting with Jira issues. The `main.py` script prompts for an issue ID and prints the raw details retrieved from Jira.
 
 ## Configuration
 
-Create a `.env` file based on `.env.example` and provide your OpenAI API key. The default model can be changed in `config.yaml` or by setting `OPENAI_MODEL` in the environment.
+Create a `.env` file based on `.env.example` and provide your Jira credentials:
+
+```
+JIRA_BASE_URL=https://your-domain.atlassian.net
+JIRA_EMAIL=your-email@example.com
+JIRA_API_TOKEN=your-api-token
+```
 
 ## Usage
 
@@ -13,3 +19,5 @@ Run the script with Python:
 ```bash
 python main.py
 ```
+
+You will be asked for a Jira issue ID and the issue data will be printed to the terminal.

--- a/main.py
+++ b/main.py
@@ -1,5 +1,37 @@
-from smolagents import CodeAgent, DuckDuckGoSearchTool, InferenceClientModel, load_tool, tool
+import json
+import os
+import requests
 
-from ui.Gradio_UI import GradioUI
 
-# Below is an example of a tool that does nothing. Amaze us with your creativity!
+def get_jira_client():
+    """Return a simple Jira REST client using environment variables."""
+    base_url = os.getenv("JIRA_BASE_URL")
+    email = os.getenv("JIRA_EMAIL")
+    token = os.getenv("JIRA_API_TOKEN")
+    if not all([base_url, email, token]):
+        raise RuntimeError(
+            "JIRA_BASE_URL, JIRA_EMAIL and JIRA_API_TOKEN must be set in the environment"
+        )
+    return base_url.rstrip("/"), (email, token)
+
+
+def get_issue(issue_key: str) -> dict:
+    base_url, auth = get_jira_client()
+    url = f"{base_url}/rest/api/3/issue/{issue_key}"
+    response = requests.get(url, auth=auth)
+    response.raise_for_status()
+    return response.json()
+
+
+def main() -> None:
+    issue_id = input("Enter Jira issue ID: ").strip()
+    try:
+        issue = get_issue(issue_id)
+    except Exception as exc:
+        print(f"Failed to fetch issue {issue_id}: {exc}")
+        return
+    print(json.dumps(issue, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement basic Jira client in `main.py`
- document setup and usage
- provide `.env.example`

## Testing
- `python main.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement openai)*

------
https://chatgpt.com/codex/tasks/task_b_68405a09e06083289ea0b743a171c157