### PR TITLE
Implement OpenAI service and basic Jira agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,23 @@
-# Hello World
+# Jira AI Assistant
 
-This repository contains a minimal Python script that prints `Hello, world!` when executed.
+This repository demonstrates a very small assistant that communicates with the OpenAI API and exposes a number of Jira related tools.  A simple wrapper around the OpenAI SDK is provided together with a service layer and a minimal agent.
 
 ## Configuration
 
-Create a `.env` file based on `.env.example` and provide your OpenAI API key. The default model can be changed in `config.yaml` or by setting `OPENAI_MODEL` in the environment.
+Create a `.env` file and provide your OpenAI API key under `OPENAI_API_KEY`.  The default model can be changed in `config.yaml` or by setting `OPENAI_MODEL` in the environment.  Jira credentials should be supplied via `JIRA_BASE_URL`, `JIRA_EMAIL` and `JIRA_API_TOKEN` when using the Jira tools.
 
 ## Usage
 
-Run the script with Python:
+The new `OpenAIService` class can be used to ask arbitrary questions via the OpenAI chat API:
 
 ```bash
-python main.py
+python openai_service.py "What is 2 + 2?"
 ```
+
+`JiraAIAgent` collects all tools defined in `jira_service.py` and exposes an `ask` method that uses the OpenAI service.  The agent can be invoked from the command line as well:
+
+```bash
+python agent.py "List the issue details for PROJ-1"
+```
+
+These examples require valid API keys for both OpenAI and Jira if the Jira tools are exercised.

--- a/agent.py
+++ b/agent.py
@@ -1,0 +1,28 @@
+from typing import List
+
+from jira_service import jira_tools
+from openai_service import OpenAIService
+
+
+class JiraAIAgent:
+    """Simple agent exposing Jira tools and OpenAI question answering."""
+
+    def __init__(self, service: OpenAIService | None = None) -> None:
+        self.service = service or OpenAIService()
+        # expose available tools so integrators can wire them as needed
+        self.tools: List = jira_tools
+
+    def ask(self, question: str) -> str:
+        """Return OpenAI's answer for the provided question."""
+        return self.service.ask_question(question)
+
+
+__all__ = ["JiraAIAgent"]
+
+
+if __name__ == "__main__":
+    import sys
+
+    prompt = " ".join(sys.argv[1:]) or input("Ask a question: ")
+    agent = JiraAIAgent()
+    print(agent.ask(prompt))

--- a/openai_service.py
+++ b/openai_service.py
@@ -1,0 +1,28 @@
+from typing import Any, List, Dict
+
+from src.llm_clients.openai_client import OpenAIClient
+
+
+class OpenAIService:
+    """High level service exposing simple question answering using OpenAI."""
+
+    def __init__(self, config_path: str = "config.yaml") -> None:
+        self.client = OpenAIClient(config_path)
+
+    def ask_question(self, question: str, **kwargs: Any) -> str:
+        """Return the assistant answer for ``question`` using OpenAI chat API."""
+        messages: List[Dict[str, str]] = [{"role": "user", "content": question}]
+        response = self.client.chat_completion(messages, **kwargs)
+        return response["choices"][0]["message"]["content"].strip()
+
+
+__all__ = ["OpenAIService"]
+
+
+if __name__ == "__main__":
+    import sys
+
+    prompt = " ".join(sys.argv[1:]) or input("Ask a question: ")
+    service = OpenAIService()
+    answer = service.ask_question(prompt)
+    print(answer)


### PR DESCRIPTION
## Summary
- add `OpenAIService` for asking questions via the OpenAI API
- add `JiraAIAgent` that exposes all Jira tools and uses the new service
- update documentation with usage examples

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68405a4f7bfc8328ab19a24d1b0f09da