### PR TITLE
Add debug logging for Jira client and service

### DIFF
--- a/jira_service.py
+++ b/jira_service.py
@@ -5,6 +5,9 @@ from typing import Dict, Any
 from langchain.tools import Tool
 
 from src.jira_client import JiraClient
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def _get_jira_client() -> JiraClient:
@@ -16,6 +19,7 @@ def _get_jira_client() -> JiraClient:
         raise ValueError(
             "JIRA_BASE_URL, JIRA_EMAIL and JIRA_API_TOKEN environment variables must be set"
         )
+    logger.debug("Creating JiraClient for base_url=%s email=%s", base_url, email)
     return JiraClient(base_url, email, token)
 
 
@@ -23,6 +27,7 @@ def _get_jira_client() -> JiraClient:
 
 def get_issue_by_id_func(issue_id: str) -> str:
     """Fetch details for a given Jira issue ID."""
+    logger.debug("Getting issue by ID: %s", issue_id)
     client = _get_jira_client()
     issue = client.get_issue(issue_id)
     return json.dumps(issue)
@@ -44,6 +49,9 @@ def create_jira_issue_func(
     summary: str, description: str, project_key: str, issue_type: str = "Task"
 ) -> str:
     """Create a new Jira issue."""
+    logger.debug(
+        "Creating Jira issue in project %s with summary %s", project_key, summary
+    )
     client = _get_jira_client()
     fields: Dict[str, Any] = {
         "project": {"key": project_key},
@@ -70,6 +78,7 @@ create_jira_issue_tool = Tool(
 
 def get_issue_comments_func(issue_id: str) -> str:
     """Fetch comments for a given Jira issue ID."""
+    logger.debug("Fetching comments for issue %s", issue_id)
     client = _get_jira_client()
     comments = client.get_comments(issue_id)
     return json.dumps(comments)
@@ -89,6 +98,7 @@ get_issue_comments_tool = Tool(
 
 def get_issue_history_func(issue_id: str) -> str:
     """Fetch the changelog for a given Jira issue ID."""
+    logger.debug("Fetching changelog for issue %s", issue_id)
     client = _get_jira_client()
     changelog = client.get_changelog(issue_id)
     return json.dumps(changelog)
@@ -107,6 +117,7 @@ get_issue_history_tool = Tool(
 
 def add_comment_to_issue_func(issue_id: str, comment: str) -> str:
     """Add a comment to the specified issue."""
+    logger.debug("Adding comment to issue %s", issue_id)
     client = _get_jira_client()
     result = client.add_comment(issue_id, comment)
     return json.dumps(result)
@@ -127,6 +138,7 @@ def update_issue_fields_func(issue_id: str, fields_json: str) -> str:
 
     ``fields_json`` should be a JSON string mapping field names to new values.
     """
+    logger.debug("Updating issue %s with fields %s", issue_id, fields_json)
     client = _get_jira_client()
     fields: Dict[str, Any] = json.loads(fields_json)
     updated = client.update_issue(issue_id, fields)

--- a/src/jira_client.py
+++ b/src/jira_client.py
@@ -1,46 +1,57 @@
 from typing import Any, Dict, List
 
 from jira import JIRA
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class JiraClient:
     """Wrapper around the official ``jira`` client exposing common helpers."""
 
     def __init__(self, base_url: str, email: str, api_token: str) -> None:
+        logger.debug("Initializing JiraClient with base_url=%s email=%s", base_url, email)
         self._jira = JIRA(server=base_url.rstrip('/'), basic_auth=(email, api_token))
 
     def get_issue(self, issue_key: str, expand: str | None = None) -> Dict[str, Any]:
         """Retrieve an issue by its key."""
+        logger.debug("Fetching issue %s", issue_key)
         issue = self._jira.issue(issue_key, expand=expand)
         return issue.raw
 
     def create_issue(self, fields: Dict[str, Any]) -> Dict[str, Any]:
         """Create a new issue and return its raw representation."""
+        logger.debug("Creating issue with fields: %s", fields)
         issue = self._jira.create_issue(fields=fields)
         return issue.raw
 
     def add_comment(self, issue_key: str, comment: str) -> Dict[str, Any]:
         """Add a comment to an issue and return the created comment."""
+        logger.debug("Adding comment to issue %s", issue_key)
         cmt = self._jira.add_comment(issue_key, comment)
         return cmt.raw
 
     def get_comments(self, issue_key: str) -> List[Dict[str, Any]]:
         """Return comments for an issue."""
+        logger.debug("Fetching comments for issue %s", issue_key)
         comments = self._jira.comments(issue_key)
         return [c.raw for c in comments]
 
     def update_issue(self, issue_key: str, fields: Dict[str, Any]) -> Dict[str, Any]:
         """Update fields of an issue."""
+        logger.debug("Updating issue %s with fields: %s", issue_key, fields)
         issue = self._jira.issue(issue_key)
         issue.update(fields=fields)
         return issue.raw
 
     def get_changelog(self, issue_key: str) -> Dict[str, Any]:
         """Return changelog for an issue."""
+        logger.debug("Fetching changelog for issue %s", issue_key)
         issue = self._jira.issue(issue_key, expand="changelog")
         return issue.raw.get("changelog", {})
 
     def search_issues(self, jql: str, **kwargs: Any) -> List[Dict[str, Any]]:
         """Run a JQL query and return the matching issues."""
+        logger.debug("Searching issues with JQL: %s", jql)
         issues = self._jira.search_issues(jql, **kwargs)
         return [iss.raw for iss in issues]


### PR DESCRIPTION
## Summary
- add `logging` with module-level logger in `src/jira_client.py`
- log when initializing client and during all Jira operations
- add similar debug logs in `jira_service.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_684067df40e48328af48b2960dd1d640