### PR TITLE
Add configurable LLM client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ JIRA_EMAIL=your-email@example.com
 JIRA_API_TOKEN=your-api-token
 OPENAI_API_KEY=your-openai-api-key
 OPENAI_MODEL=gpt-4o-mini
+BASE_LLM=openai  # or 'anthropic'
 ```
 
-The default model can be changed in `src/configs/config.yaml` or by setting `OPENAI_MODEL` in the environment.
+The default model and provider can be changed in `src/configs/config.yaml` or by setting `OPENAI_MODEL` and `BASE_LLM` in the environment.
 
 ## Usage
 

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,11 +1,6 @@
-"""
-Agents module for the Jira AI Assistant.
+"""Agents for the Jira AI Assistant."""
 
-This module contains AI agents for various tasks like classification and API validation.
-"""
+from .classifier import ClassifierAgent
 
-# Note: Import agents as they are implemented
-# from .classifier import ... (add specific imports when files are populated)
-# from .api_validator import ... (add specific imports when files are populated)
+__all__ = ["ClassifierAgent"]
 
-__all__ = []  # Add exports when agent files are fully implemented 

--- a/src/agents/classifier.py
+++ b/src/agents/classifier.py
@@ -1,0 +1,34 @@
+"""Simple classifier agent using a configurable LLM provider."""
+
+from typing import List, Dict, Any
+
+from configs import load_config
+from src.llm_clients.openai_client import OpenAIClient
+from src.llm_clients.claude_client import ClaudeClient
+
+
+class ClassifierAgent:
+    """Agent that selects an LLM client based on configuration."""
+
+    def __init__(self, config_path: str | None = None) -> None:
+        self.config = load_config(config_path)
+        llm = self.config.base_llm.lower()
+        if llm == "openai":
+            self.client = OpenAIClient(config_path)
+        elif llm in {"anthropic", "claude"}:
+            self.client = ClaudeClient(config_path)
+        else:
+            raise ValueError(f"Unsupported LLM provider: {self.config.base_llm}")
+
+    def classify(self, prompt: str, **kwargs: Any) -> Any:
+        """Return the classification result for ``prompt``."""
+        messages: List[Dict[str, str]] = [{"role": "user", "content": prompt}]
+        response = self.client.chat_completion(messages, **kwargs)
+        try:
+            return response["choices"][0]["message"]["content"].strip()
+        except Exception:
+            return response
+
+
+__all__ = ["ClassifierAgent"]
+

--- a/src/configs/__init__.py
+++ b/src/configs/__init__.py
@@ -1,9 +1,6 @@
-"""
-Configuration module for the Jira AI Assistant.
-
-This module handles loading configuration from YAML files and environment variables.
-"""
+"""Configuration loader for the Jira AI Assistant."""
 
 from .config import Config, load_config
 
-__all__ = ["Config", "load_config"] 
+__all__ = ["Config", "load_config"]
+

--- a/src/configs/config.py
+++ b/src/configs/config.py
@@ -5,8 +5,11 @@ from dotenv import load_dotenv
 
 @dataclass
 class Config:
+    base_llm: str
     openai_api_key: str
     openai_model: str
+    anthropic_api_key: str
+    anthropic_model: str
 
 
 def load_config(path: str = None) -> Config:
@@ -23,6 +26,9 @@ def load_config(path: str = None) -> Config:
         with open(path, "r", encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
     return Config(
+        base_llm=data.get("base_llm", os.getenv("BASE_LLM", "openai")),
         openai_api_key=os.getenv("OPENAI_API_KEY", data.get("openai_api_key", "")),
         openai_model=os.getenv("OPENAI_MODEL", data.get("openai_model", "gpt-3.5-turbo")),
+        anthropic_api_key=os.getenv("ANTHROPIC_API_KEY", data.get("anthropic_api_key", "")),
+        anthropic_model=os.getenv("ANTHROPIC_MODEL", data.get("anthropic_model", "claude-3-opus")),
     )

--- a/src/configs/config.yaml
+++ b/src/configs/config.yaml
@@ -1,1 +1,3 @@
+base_llm: openai
 openai_model: gpt-3.5-turbo
+anthropic_model: claude-3-opus

--- a/src/llm_clients/__init__.py
+++ b/src/llm_clients/__init__.py
@@ -1,9 +1,7 @@
-"""
-LLM Clients module for the Jira AI Assistant.
-
-This module contains clients for various Large Language Model services.
-"""
+"""LLM client implementations."""
 
 from .openai_client import OpenAIClient
+from .claude_client import ClaudeClient
 
-__all__ = ["OpenAIClient"] 
+__all__ = ["OpenAIClient", "ClaudeClient"]
+

--- a/src/llm_clients/base_llm_client.py
+++ b/src/llm_clients/base_llm_client.py
@@ -1,0 +1,17 @@
+"""Abstract base class for LLM clients."""
+
+from abc import ABC, abstractmethod
+from typing import List, Dict, Any
+
+
+class BaseLLMClient(ABC):
+    """Interface that all LLM clients must implement."""
+
+    @abstractmethod
+    def chat_completion(self, messages: List[Dict[str, str]], **kwargs: Any) -> Any:
+        """Return a chat completion response."""
+        raise NotImplementedError
+
+
+__all__ = ["BaseLLMClient"]
+

--- a/src/llm_clients/claude_client.py
+++ b/src/llm_clients/claude_client.py
@@ -1,0 +1,22 @@
+"""Placeholder client for Anthropic Claude."""
+
+from typing import List, Dict, Any
+
+from configs.config import load_config
+from src.llm_clients.base_llm_client import BaseLLMClient
+
+
+class ClaudeClient(BaseLLMClient):
+    """Stub implementation for Anthropic's Claude API."""
+
+    def __init__(self, config_path: str | None = None) -> None:
+        self.config = load_config(config_path)
+        # Actual client initialization would go here.
+
+    def chat_completion(self, messages: List[Dict[str, str]], **kwargs: Any) -> Any:
+        """Create a chat completion using Claude."""
+        raise NotImplementedError("Claude client not implemented")
+
+
+__all__ = ["ClaudeClient"]
+

--- a/src/llm_clients/openai_client.py
+++ b/src/llm_clients/openai_client.py
@@ -2,9 +2,10 @@ import openai
 from typing import List, Dict, Any
 
 from configs.config import load_config
+from src.llm_clients.base_llm_client import BaseLLMClient
 
 
-class OpenAIClient:
+class OpenAIClient(BaseLLMClient):
     """Simple wrapper around the OpenAI SDK."""
 
     def __init__(self, config_path: str = None) -> None:
@@ -18,3 +19,6 @@ class OpenAIClient:
             messages=messages,
             **kwargs,
         )
+
+
+__all__ = ["OpenAIClient"]

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,10 +1,7 @@
-"""
-Services module for the Jira AI Assistant.
-
-This module contains high-level services for interacting with Jira and OpenAI.
-"""
+"""Service layer for the Jira AI Assistant."""
 
 from .openai_service import OpenAIService
 from .jira_service import JiraService
 
-__all__ = ["OpenAIService", "JiraService"] 
+__all__ = ["OpenAIService", "JiraService"]
+

--- a/src/ui/__init__.py
+++ b/src/ui/__init__.py
@@ -1,10 +1,4 @@
-"""
-User Interface module for the Jira AI Assistant.
+"""UI components for the Jira AI Assistant."""
 
-This module contains UI components and interfaces for the application.
-"""
+__all__: list[str] = []
 
-# Note: Import Gradio_UI components as needed
-# from .Gradio_UI import ... (add specific imports when the file is populated)
-
-__all__ = []  # Add exports when Gradio_UI is fully implemented 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,8 +1,4 @@
-"""
-Utilities module for the Jira AI Assistant.
+"""Utility helpers for the Jira AI Assistant."""
 
-This module contains utility functions and helper classes.
-"""
+__all__: list[str] = []
 
-# Add utility imports here as they are implemented
-__all__ = [] 


### PR DESCRIPTION
## Summary
- support selecting LLM provider in `config.yaml`
- load provider details in `Config`
- add abstract `BaseLLMClient`
- implement `OpenAIClient` using the interface
- add stub `ClaudeClient`
- implement `ClassifierAgent` that picks client based on config
- clean up module `__init__` files and update README

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement openai)*

------
https://chatgpt.com/codex/tasks/task_b_68415a91a2f083289514c0b36e7d014c