### PR TITLE
Add Jira issue classification

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,8 @@
-import json
 import os
 from dotenv import load_dotenv
 from src.jira_client import JiraClient
+from src.agents.classifier import ClassifierAgent
+from src.prompts import load_prompt
 
 # Load environment variables from .env file (force reload)
 load_dotenv(override=True)
@@ -27,40 +28,37 @@ def main() -> None:
     try:
         client = get_jira_client()
         print("Jira client initialized successfully")
-        
-        print("\nSearching for recent issues you can access...")
-        issues = client.search_issues("ORDER BY updated DESC", maxResults=10)
-        
-        if issues:
-            print(f"Found {len(issues)} accessible issues:")
-            projects_found = set()
-            for issue in issues:
-                project_key = issue['fields']['project']['key']
-                projects_found.add(project_key)
-                print(f"  {issue['key']} ({project_key}): {issue['fields']['summary'][:50]}...")
-            
-            print(f"\nAccessible projects: {', '.join(sorted(projects_found))}")
-        else:
-            print("No issues found")
-        
     except Exception as exc:
-        print(f"Failed to search issues: {exc}")
+        print(f"Failed to initialize Jira client: {exc}")
         return
-    
-    print("\n" + "-" * 60)
+
     issue_id = input("Enter Jira issue ID: ").strip()
-    
+
     try:
         issue = client.get_issue(issue_id)
         print("\nIssue found:")
         print(f"Key: {issue['key']}")
-        print(f"Project: {issue['fields']['project']['key']} - {issue['fields']['project']['name']}")
+        print(
+            f"Project: {issue['fields']['project']['key']} - {issue['fields']['project']['name']}"
+        )
         print(f"Summary: {issue['fields']['summary']}")
         print(f"Status: {issue['fields']['status']['name']}")
-        print(f"Assignee: {issue['fields']['assignee']['displayName'] if issue['fields']['assignee'] else 'Unassigned'}")
+        assignee = issue['fields']['assignee']['displayName'] if issue['fields']['assignee'] else 'Unassigned'
+        print(f"Assignee: {assignee}")
         print(f"Reporter: {issue['fields']['reporter']['displayName']}")
         print(f"Created: {issue['fields']['created']}")
         print(f"Updated: {issue['fields']['updated']}")
+
+        # Classify issue using the LLM
+        prompt_template = load_prompt("classifier.txt")
+        prompt = prompt_template.format(
+            summary=issue['fields'].get('summary', ''),
+            description=issue['fields'].get('description', '')
+        )
+        agent = ClassifierAgent()
+        classification = agent.classify(prompt)
+        print(f"\nClassification: {classification}")
+
     except Exception as exc:
         print(f"Failed to fetch issue {issue_id}: {exc}")
 

--- a/src/prompts/classifier.txt
+++ b/src/prompts/classifier.txt
@@ -1,0 +1,7 @@
+
+You are a helpful assistant that reviews Jira issues and determines if they are about API topics.
+Given the issue summary and description, respond with only one label:
+"API_RELATED" or "NOT_API_RELATED".
+
+Summary: {summary}
+Description: {description}


### PR DESCRIPTION
## Summary
- simplify `main.py` to only fetch a Jira issue by ID
- feed the issue details to `ClassifierAgent` via OpenAI
- add a short prompt in `classifier.txt` for API related detection

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68415d84e0048328ad7a30b232c2f414