### PR TITLE
Fix OpenAI SDK usage

### DIFF
--- a/src/agents/classifier.py
+++ b/src/agents/classifier.py
@@ -25,9 +25,12 @@ class ClassifierAgent:
         messages: List[Dict[str, str]] = [{"role": "user", "content": prompt}]
         response = self.client.chat_completion(messages, **kwargs)
         try:
-            return response["choices"][0]["message"]["content"].strip()
+            return response.choices[0].message.content.strip()
         except Exception:
-            return response
+            try:
+                return response["choices"][0]["message"]["content"].strip()
+            except Exception:
+                return response
 
 
 __all__ = ["ClassifierAgent"]

--- a/src/llm_clients/openai_client.py
+++ b/src/llm_clients/openai_client.py
@@ -1,6 +1,6 @@
 # Import src package first to ensure path setup
 
-import openai
+from openai import OpenAI
 from typing import List, Dict, Any
 
 from src.configs.config import load_config
@@ -12,11 +12,11 @@ class OpenAIClient(BaseLLMClient):
 
     def __init__(self, config_path: str = None) -> None:
         self.config = load_config(config_path)
-        openai.api_key = self.config.openai_api_key
+        self.client = OpenAI(api_key=self.config.openai_api_key)
 
     def chat_completion(self, messages: List[Dict[str, str]], **kwargs: Any) -> Any:
         """Create a chat completion using the configured model."""
-        return openai.ChatCompletion.create(
+        return self.client.chat.completions.create(
             model=self.config.openai_model,
             messages=messages,
             **kwargs,

--- a/src/services/openai_service.py
+++ b/src/services/openai_service.py
@@ -13,7 +13,7 @@ class OpenAIService:
         """Return the assistant answer for ``question`` using OpenAI chat API."""
         messages: List[Dict[str, str]] = [{"role": "user", "content": question}]
         response = self.client.chat_completion(messages, **kwargs)
-        return response["choices"][0]["message"]["content"].strip()
+        return response.choices[0].message.content.strip()
 
 
 __all__ = ["OpenAIService"]


### PR DESCRIPTION
## Summary
- update OpenAI client wrapper for openai>=1.0 interface
- adapt services and agent to parse the new ChatCompletion objects

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684161c0c2088328b99d05c303b74475