### PR TITLE
Add debug logging for llm clients

### DIFF
--- a/src/llm_clients/__init__.py
+++ b/src/llm_clients/__init__.py
@@ -1,7 +1,12 @@
 """LLM client implementations."""
 
+import logging
+
 from .openai_client import OpenAIClient
 from .claude_client import ClaudeClient
+
+logger = logging.getLogger(__name__)
+logger.debug("llm_clients package initialized")
 
 __all__ = ["OpenAIClient", "ClaudeClient"]
 

--- a/src/llm_clients/base_llm_client.py
+++ b/src/llm_clients/base_llm_client.py
@@ -2,6 +2,10 @@
 
 from abc import ABC, abstractmethod
 from typing import List, Dict, Any
+import logging
+
+logger = logging.getLogger(__name__)
+logger.debug("BaseLLMClient module loaded")
 
 
 class BaseLLMClient(ABC):

--- a/src/llm_clients/claude_client.py
+++ b/src/llm_clients/claude_client.py
@@ -1,20 +1,29 @@
 """Placeholder client for Anthropic Claude."""
 
 from typing import List, Dict, Any
+import logging
 
 from src.configs.config import load_config
 from src.llm_clients.base_llm_client import BaseLLMClient
+
+logger = logging.getLogger(__name__)
 
 
 class ClaudeClient(BaseLLMClient):
     """Stub implementation for Anthropic's Claude API."""
 
     def __init__(self, config_path: str | None = None) -> None:
+        logger.debug("Initializing ClaudeClient with config_path=%s", config_path)
         self.config = load_config(config_path)
         # Actual client initialization would go here.
 
     def chat_completion(self, messages: List[Dict[str, str]], **kwargs: Any) -> Any:
         """Create a chat completion using Claude."""
+        logger.debug(
+            "Creating Claude chat completion with messages=%s kwargs=%s",
+            messages,
+            kwargs,
+        )
         raise NotImplementedError("Claude client not implemented")
 
 

--- a/src/llm_clients/openai_client.py
+++ b/src/llm_clients/openai_client.py
@@ -2,20 +2,29 @@
 
 from openai import OpenAI
 from typing import List, Dict, Any
+import logging
 
 from src.configs.config import load_config
 from src.llm_clients.base_llm_client import BaseLLMClient
+
+logger = logging.getLogger(__name__)
 
 
 class OpenAIClient(BaseLLMClient):
     """Simple wrapper around the OpenAI SDK."""
 
     def __init__(self, config_path: str = None) -> None:
+        logger.debug("Initializing OpenAIClient with config_path=%s", config_path)
         self.config = load_config(config_path)
         self.client = OpenAI(api_key=self.config.openai_api_key)
 
     def chat_completion(self, messages: List[Dict[str, str]], **kwargs: Any) -> Any:
         """Create a chat completion using the configured model."""
+        logger.debug(
+            "Creating chat completion with messages=%s kwargs=%s",
+            messages,
+            kwargs,
+        )
         return self.client.chat.completions.create(
             model=self.config.openai_model,
             messages=messages,


### PR DESCRIPTION
## Summary
- enable debug logs when importing llm clients package
- add logger initialization to base, OpenAI and Claude clients
- log initialization and chat completions for OpenAI and Claude clients

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_6841657974a083289dd6f0e6bc89da54