### PR TITLE
Add config.yml and logging setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ OPENAI_MODEL=gpt-4o-mini
 BASE_LLM=openai  # or 'anthropic'
 ```
 
-The default model and provider can be changed in `src/configs/config.yaml` or by setting `OPENAI_MODEL` and `BASE_LLM` in the environment.
+The default model and provider can be changed in `src/configs/config.yml` or by setting `OPENAI_MODEL` and `BASE_LLM` in the environment.
 
 ## Usage
 

--- a/main.py
+++ b/main.py
@@ -3,9 +3,14 @@ from dotenv import load_dotenv
 from src.jira_client import JiraClient
 from src.agents.classifier import ClassifierAgent
 from src.prompts import load_prompt
+from src.configs import load_config, setup_logging
 
 # Load environment variables from .env file (force reload)
 load_dotenv(override=True)
+
+# Load application configuration and configure logging
+config = load_config()
+setup_logging(config)
 
 
 def get_jira_client():

--- a/src/configs/__init__.py
+++ b/src/configs/__init__.py
@@ -1,6 +1,6 @@
 """Configuration loader for the Jira AI Assistant."""
 
-from .config import Config, load_config
+from .config import Config, load_config, setup_logging
 
-__all__ = ["Config", "load_config"]
+__all__ = ["Config", "load_config", "setup_logging"]
 

--- a/src/configs/config.py
+++ b/src/configs/config.py
@@ -1,15 +1,29 @@
 from dataclasses import dataclass
 import os
+import logging
 import yaml
 from dotenv import load_dotenv
 
+
 @dataclass
 class Config:
+    app_name: str
+    environment: str
+    debug: bool
     base_llm: str
     openai_api_key: str
     openai_model: str
     anthropic_api_key: str
     anthropic_model: str
+
+
+def setup_logging(config: "Config") -> None:
+    """Configure logging level based on ``config.debug``."""
+    level = logging.DEBUG if config.debug else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
 
 
 def load_config(path: str = None) -> Config:
@@ -19,13 +33,23 @@ def load_config(path: str = None) -> Config:
     # If no path provided, use default relative to this config.py file
     if path is None:
         config_dir = os.path.dirname(os.path.abspath(__file__))
-        path = os.path.join(config_dir, "config.yaml")
+        path = os.path.join(config_dir, "config.yml")
     
     data = {}
     if os.path.exists(path):
         with open(path, "r", encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
+
+    def _env_bool(name: str, default: bool) -> bool:
+        val = os.getenv(name)
+        if val is None:
+            return bool(data.get(name.lower(), default))
+        return val.lower() in {"1", "true", "yes", "on"}
+
     return Config(
+        app_name=data.get("app_name", os.getenv("APP_NAME", "JiraAIAssistant")),
+        environment=data.get("environment", os.getenv("ENVIRONMENT", "production")),
+        debug=_env_bool("DEBUG", data.get("debug", False)),
         base_llm=data.get("base_llm", os.getenv("BASE_LLM", "openai")),
         openai_api_key=os.getenv("OPENAI_API_KEY", data.get("openai_api_key", "")),
         openai_model=os.getenv("OPENAI_MODEL", data.get("openai_model", "gpt-3.5-turbo")),

--- a/src/configs/config.yml
+++ b/src/configs/config.yml
@@ -1,3 +1,6 @@
+app_name: VirtualLibrary
+environment: development
+debug: true
 base_llm: openai
 openai_model: gpt-3.5-turbo
 anthropic_model: claude-3-opus

--- a/src/services/openai_service.py
+++ b/src/services/openai_service.py
@@ -2,6 +2,7 @@ from typing import Any, List, Dict
 
 from src.llm_clients.openai_client import OpenAIClient
 import logging
+from src.configs import load_config, setup_logging
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +29,9 @@ __all__ = ["OpenAIService"]
 
 if __name__ == "__main__":
     import sys
+
+    cfg = load_config()
+    setup_logging(cfg)
 
     prompt = " ".join(sys.argv[1:]) or input("Ask a question: ")
     service = OpenAIService()


### PR DESCRIPTION
## Summary
- rename `config.yaml` to `config.yml` and extend it with app settings
- support new config options and logging setup in `Config`
- update exports in `src.configs`
- configure logging in `main.py` and `openai_service.py`
- document updated config file name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684168a407508328ac0d2b82ec5a9cbb