### PR TITLE
Add Langfuse monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains a Jira AI assistant that communicates with the OpenAI A
 - Simple utilities for retrieving Jira issue details
 - OpenAI service integration for AI-powered assistance
 - A minimal agent that combines both capabilities
+- Optional Langfuse integration for monitoring LLM calls
 
 ## Configuration
 
@@ -17,9 +18,17 @@ JIRA_API_TOKEN=your-api-token
 OPENAI_API_KEY=your-openai-api-key
 OPENAI_MODEL=gpt-4o-mini
 BASE_LLM=openai  # or 'anthropic'
+LANGFUSE_PUBLIC_KEY=your-langfuse-public-key
+LANGFUSE_SECRET_KEY=your-langfuse-secret-key
+# Optional custom host, defaults to Langfuse cloud
+LANGFUSE_HOST=https://app.langfuse.com
 ```
 
 The default model and provider can be changed in `src/configs/config.yml` or by setting `OPENAI_MODEL` and `BASE_LLM` in the environment.
+
+If `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` are provided, all LLM calls
+will be reported to Langfuse. Set `LANGFUSE_HOST` when using a self-hosted
+instance.
 
 ## Usage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ PyYAML
 requests
 gradio
 jira
+langfuse

--- a/src/llm_clients/openai_client.py
+++ b/src/llm_clients/openai_client.py
@@ -3,6 +3,12 @@
 from openai import OpenAI
 from typing import List, Dict, Any
 import logging
+import os
+
+try:
+    from langfuse import Langfuse
+except Exception:  # pragma: no cover - optional dependency
+    Langfuse = None  # type: ignore
 
 from src.configs.config import load_config
 from src.llm_clients.base_llm_client import BaseLLMClient
@@ -17,6 +23,21 @@ class OpenAIClient(BaseLLMClient):
         logger.debug("Initializing OpenAIClient with config_path=%s", config_path)
         self.config = load_config(config_path)
         self.client = OpenAI(api_key=self.config.openai_api_key)
+        self.langfuse = None
+        if Langfuse is not None:
+            public = os.getenv("LANGFUSE_PUBLIC_KEY")
+            secret = os.getenv("LANGFUSE_SECRET_KEY")
+            host = os.getenv("LANGFUSE_HOST")
+            if public and secret:
+                try:
+                    self.langfuse = Langfuse(
+                        public_key=public,
+                        secret_key=secret,
+                        host=host,
+                    )
+                    logger.info("Langfuse monitoring enabled")
+                except Exception:  # pragma: no cover - fail gracefully
+                    logger.exception("Failed to initialize Langfuse")
 
     def chat_completion(self, messages: List[Dict[str, str]], **kwargs: Any) -> Any:
         """Create a chat completion using the configured model."""
@@ -25,11 +46,39 @@ class OpenAIClient(BaseLLMClient):
             messages,
             kwargs,
         )
-        return self.client.chat.completions.create(
+        trace = None
+        if self.langfuse:
+            try:
+                trace = self.langfuse.trace(name="openai.chat_completion")
+            except Exception:  # pragma: no cover - monitoring optional
+                logger.exception("Failed to start Langfuse trace")
+                trace = None
+        response = self.client.chat.completions.create(
             model=self.config.openai_model,
             messages=messages,
             **kwargs,
         )
+        if trace:
+            try:
+                prompt = messages[-1].get("content", "") if messages else ""
+                completion = (
+                    response.choices[0].message.content.strip()
+                    if hasattr(response, "choices")
+                    else ""
+                )
+                trace.generation(
+                    input=prompt,
+                    output=completion,
+                    model=self.config.openai_model,
+                )
+            except Exception:  # pragma: no cover
+                logger.exception("Failed to log Langfuse generation")
+            finally:
+                try:
+                    trace.end()
+                except Exception:  # pragma: no cover
+                    logger.exception("Failed to end Langfuse trace")
+        return response
 
 
 __all__ = ["OpenAIClient"]


### PR DESCRIPTION
## Summary
- integrate optional Langfuse tracing in OpenAIClient
- document Langfuse env vars in README
- include langfuse in requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68417ec2b2d88328a6140d294f54fece