### PR TITLE
Implement ApiValidator agent

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -4,9 +4,10 @@ import logging
 
 logger = logging.getLogger(__name__)
 logger.debug("agents package loaded")
-logger.info("ClassifierAgent will be exported")
+logger.info("ClassifierAgent and ApiValidatorAgent will be exported")
 
 from .classifier import ClassifierAgent
+from .api_validator import ApiValidatorAgent
 
-__all__ = ["ClassifierAgent"]
+__all__ = ["ClassifierAgent", "ApiValidatorAgent"]
 

--- a/src/agents/api_validator.py
+++ b/src/agents/api_validator.py
@@ -1,8 +1,90 @@
-"""API Validator agent stubs for Jira AI Assistant."""
+"""API Validator agent for Jira AI Assistant."""
+
+from __future__ import annotations
 
 import logging
+from typing import Any, Dict
+
+import yaml
+
+from src.prompts import load_prompt, PROMPTS_DIR
+from src.configs.config import load_config
+from src.llm_clients.openai_client import OpenAIClient
+from src.llm_clients.claude_client import ClaudeClient
 
 logger = logging.getLogger(__name__)
 logger.debug("api_validator module loaded")
-logger.info("API Validator agent not yet implemented")
+
+
+def _load_status_prompts() -> Dict[str, str]:
+    """Return a mapping of Jira statuses to prompt templates."""
+    text = load_prompt("api_validator.txt")
+    if not text:
+        logger.warning("api_validator.txt not found or empty")
+        return {}
+    try:
+        prompts = yaml.safe_load(text) or {}
+        if not isinstance(prompts, dict):
+            logger.error("api_validator.txt must define a mapping of status to prompt")
+            return {}
+        logger.debug("Loaded %d status prompts", len(prompts))
+        return {str(k): str(v) for k, v in prompts.items()}
+    except yaml.YAMLError:
+        logger.exception("Failed to parse api_validator.txt as YAML")
+        return {}
+
+
+class ApiValidatorAgent:
+    """Agent that validates Jira issues based on their status."""
+
+    def __init__(self, config_path: str | None = None) -> None:
+        logger.debug("Initializing ApiValidatorAgent with config_path=%s", config_path)
+        self.config = load_config(config_path)
+        llm = self.config.base_llm.lower()
+        if llm == "openai":
+            logger.debug("Using OpenAIClient")
+            self.client = OpenAIClient(config_path)
+        elif llm in {"anthropic", "claude"}:
+            logger.debug("Using ClaudeClient")
+            self.client = ClaudeClient(config_path)
+        else:
+            logger.error("Unsupported LLM provider: %s", self.config.base_llm)
+            raise ValueError(f"Unsupported LLM provider: {self.config.base_llm}")
+
+        self.prompts = _load_status_prompts()
+
+    def validate(self, issue: Dict[str, Any], **kwargs: Any) -> Any:
+        """Validate ``issue`` according to its status using the configured LLM."""
+        fields = issue.get("fields", {})
+        status = fields.get("status", {}).get("name", "").replace(" ", "")
+        logger.info("Validating issue %s with status %s", issue.get("key"), status)
+
+        template = self.prompts.get(status)
+        if not template:
+            logger.warning("No prompt found for status %s", status)
+            return ""
+
+        prompt = template.format(
+            key=issue.get("key", ""),
+            summary=fields.get("summary", ""),
+            description=fields.get("description", ""),
+            status=status,
+        )
+        logger.debug("Prompt for validation: %s", prompt)
+        messages = [{"role": "user", "content": prompt}]
+        response = self.client.chat_completion(messages, **kwargs)
+        try:
+            result = response.choices[0].message.content.strip()
+        except Exception:  # pragma: no cover - handle unexpected structures
+            try:
+                result = response["choices"][0]["message"]["content"].strip()
+            except Exception:
+                logger.exception("Failed to parse response")
+                result = response
+        logger.info("Validation result: %s", result)
+        return result
+
+
+__all__ = ["ApiValidatorAgent"]
+
 

--- a/src/prompts/api_validator.txt
+++ b/src/prompts/api_validator.txt
@@ -1,0 +1,13 @@
+
+ReadyForDevelopment: |
+  You are a Jira assistant validating issues that are "Ready for Development".
+  Review the summary and description and respond with "VALID" if everything
+  required for development is clearly provided, otherwise respond with "INVALID".
+
+ReadyForVerification: |
+  You are verifying an issue that is "Ready for Verification". Determine whether
+  test steps or acceptance criteria are present. Respond with "VALID" or "INVALID".
+
+DONE: |
+  The issue is marked as done. Confirm that resolution information is included
+  and reply with "VALID" or "INVALID".


### PR DESCRIPTION
## Summary
- add an ApiValidatorAgent that reads prompts from api_validator.txt
- use YAML-based mapping of Jira statuses to prompts
- export ApiValidatorAgent in agents package
- provide example prompts for each status

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_684186bb73b48328adf12d267e1cee14