### PR TITLE
Implement classifier-validator pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ The `main.py` script prompts for an issue ID and prints the issue details:
 python main.py
 ```
 
+### Classification and Validation Pipeline
+
+`main.py` now chains the classifier and API validator using LangChain's
+`RunnableSequence`. Enter a Jira issue ID and the script will fetch the issue
+with the `get_issue_by_id` tool, classify whether it is API related and, if so,
+validate it based on the issue status.
+
 ### OpenAI Service
 
 The `OpenAIService` class can be used to ask arbitrary questions via the OpenAI chat API:

--- a/src/agents/classifier.py
+++ b/src/agents/classifier.py
@@ -6,6 +6,7 @@ import logging
 from src.configs.config import load_config
 from src.llm_clients.openai_client import OpenAIClient
 from src.llm_clients.claude_client import ClaudeClient
+from src.services.jira_service import get_issue_by_id_tool
 
 logger = logging.getLogger(__name__)
 logger.debug("classifier module loaded")
@@ -28,6 +29,9 @@ class ClassifierAgent:
         else:
             logger.error("Unsupported LLM provider: %s", self.config.base_llm)
             raise ValueError(f"Unsupported LLM provider: {self.config.base_llm}")
+
+        # Tools available to this agent
+        self.tools = [get_issue_by_id_tool]
 
     def classify(self, prompt: str, **kwargs: Any) -> Any:
         """Return the classification result for ``prompt``."""


### PR DESCRIPTION
## Summary
- expose `get_issue_by_id_tool` on `ClassifierAgent`
- chain classification and validation in `main.py` using `RunnableSequence`
- document the new flow in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68418d196abc83289c017c357c64f5f5