### PR TITLE
Improve Done status validation prompt

### DIFF
--- a/src/prompts/api_validator.txt
+++ b/src/prompts/api_validator.txt
@@ -8,6 +8,51 @@ ReadyForVerification: |
   You are verifying an issue that is "Ready for Verification". Determine whether
   test steps or acceptance criteria are present. Respond with "VALID" or "INVALID".
 
-DONE: |
-  The issue is marked as done. Confirm that resolution information is included
-  and reply with "VALID" or "INVALID".
+Done: |
+  You are an API documentation validator reviewing a JIRA ticket with status "Done." Everything should already be final. Perform a complete, strict validation of all fields and verify consistency (e.g., that the provided examples match what you see in Swagger).
+
+  Required Fields (all must exist and be correct):
+  1. **Swagger/OpenAPI URL**
+     - Must be a link containing "swagger" or "openapi" (e.g., "swagger-ui" path or a .json spec).
+  2. **HTTP Method**
+     - Exactly one of "POST", "GET", "PUT", or "DELETE" in uppercase.
+  3. **API Endpoint URL**
+     - A full URL (starting with "http://" or "https://").
+  4. **Request Body Example** (for POST/PUT)
+     - A fenced code block with valid JSON.
+     - If it’s a GET or DELETE, explicitly set `"request_body_example": null`.
+  5. **Expected Response Example**
+     - A fenced code block with valid JSON.
+     - If there is no response body (e.g., DELETE returning 204), set `"response_example": null`.
+
+  Additional Consistency Check (for "Done"):
+  - If a Swagger URL is provided, fetch (or reference) the OpenAPI spec and confirm that:
+    - The `"method"` and `"api_url"` exist in the spec's paths.
+    - The `"request_body_example"` schema aligns with the spec's request schema.
+    - The `"response_example"` schema aligns with the spec's response schema.
+    - If any mismatch, list it under `"errors"`.
+
+  **Instructions:**
+  - Parse the "Summary" and "Description." Ignore Jira-specific color tags or images unless they carry URLs or JSON blocks.
+  - Because the status is "Done," every required field must be valid. If a field is missing or inconsistent, set it to `null` and list a clear error.
+  - For consistency against Swagger, you may assume the model can "fetch" or "know" the spec details when you include the URL. If you cannot verify programmatically, simply state in errors "Swagger check could not be completed."
+  - Return exactly one JSON object (no extra commentary) according to the schema below.
+
+  **Output JSON Schema:**
+  ```json
+  {
+    "is_valid": true | false,
+    "errors": ["list of missing, malformed, or inconsistent fields"],
+    "parsed": {
+      "swagger_url": "string or null",
+      "method": "POST" | "GET" | "PUT" | "DELETE" | null,
+      "api_url": "string or null",
+      "request_body_example": { ... } | null,
+      "response_example": { ... } | null
+    }
+  }
+  ```
+
+  Issue Key: {key}
+  Summary: {summary}
+  Description: {description}


### PR DESCRIPTION
## Summary
- expand the validation instructions for issues in **Done** status
- describe required fields, consistency checks, and structured JSON output

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68418e9aa7908328a21bcd06a7f4a30e