### PR TITLE
Fix import error in services package

### DIFF
--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -6,7 +6,6 @@ logger = logging.getLogger(__name__)
 logger.debug("services package initialized")
 
 from .openai_service import OpenAIService
-from .jira_service import JiraService
 
-__all__ = ["OpenAIService", "JiraService"]
+__all__ = ["OpenAIService"]
 


### PR DESCRIPTION
## Summary
- remove unused `JiraService` import that caused ImportError

## Testing
- `pytest -q`
- `python main.py --help` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_68418f5c87048328b254c5eef98fbf90