### PR TITLE
Handle Atlassian format descriptions in validator

### DIFF
--- a/src/agents/api_validator.py
+++ b/src/agents/api_validator.py
@@ -7,7 +7,8 @@ from typing import Any, Dict
 
 import yaml
 
-from src.prompts import load_prompt, PROMPTS_DIR
+from src.prompts import load_prompt
+from src.utils import extract_plain_text
 from src.configs.config import load_config
 from src.llm_clients.openai_client import OpenAIClient
 from src.llm_clients.claude_client import ClaudeClient
@@ -66,8 +67,8 @@ class ApiValidatorAgent:
 
         prompt = template.format(
             key=issue.get("key", ""),
-            summary=fields.get("summary", ""),
-            description=fields.get("description", ""),
+            summary=extract_plain_text(fields.get("summary")),
+            description=extract_plain_text(fields.get("description")),
             status=status,
         )
         logger.debug("Prompt for validation: %s", prompt)

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,4 +1,5 @@
 """Utility helpers for the Jira AI Assistant."""
 
-__all__: list[str] = []
+from .jira import extract_plain_text
 
+__all__ = ["extract_plain_text"]

--- a/src/utils/jira.py
+++ b/src/utils/jira.py
@@ -1,0 +1,28 @@
+"""Jira-related helper utilities."""
+from typing import Any, List
+
+
+def extract_plain_text(content: Any) -> str:
+    """Return plain text from Jira fields that may use Atlassian Document Format."""
+    if isinstance(content, str):
+        return content
+
+    parts: List[str] = []
+
+    def _walk(node: Any) -> None:
+        if isinstance(node, dict):
+            text = node.get("text")
+            if text:
+                parts.append(str(text))
+            for child in node.get("content", []):
+                _walk(child)
+        elif isinstance(node, list):
+            for item in node:
+                _walk(item)
+
+    if content is not None:
+        _walk(content)
+    return " ".join(parts).strip()
+
+
+__all__ = ["extract_plain_text"]


### PR DESCRIPTION
## Summary
- parse Jira description fields that use Atlassian Document Format
- apply plain text extraction before sending to the LLM
- move plain text extractor to `utils.jira` so other modules can reuse it

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6841911f7ef48328936a87498035c5b2