### PR TITLE
Fix missing InDevelopment prompt

### DIFF
--- a/src/prompts/api_validator.txt
+++ b/src/prompts/api_validator.txt
@@ -8,6 +8,11 @@ ReadyForVerification: |
   You are verifying an issue that is "Ready for Verification". Determine whether
   test steps or acceptance criteria are present. Respond with "VALID" or "INVALID".
 
+InDevelopment: |
+  You are validating an issue currently marked as "In Development".
+  Ensure implementation details or subtasks are clear enough for work to continue.
+  Respond with "VALID" if development can proceed, otherwise respond with "INVALID".
+
 Done: |
   You are an API documentation validator reviewing a JIRA ticket with status "Done." Everything should already be final. Perform a complete, strict validation of all fields and verify consistency (e.g., that the provided examples match what you see in Swagger).
 


### PR DESCRIPTION
## Summary
- add missing InDevelopment status prompt to the API validator

## Testing
- `python -m compileall -q src`


------
https://chatgpt.com/codex/tasks/task_b_684196e4c4e88328aaefde987ea5fd6b