### PR TITLE
Add RouterAgent for routing questions

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -11,6 +11,7 @@ logger.info(
 from .classifier import ClassifierAgent
 from .api_validator import ApiValidatorAgent
 from .issue_insights import IssueInsightsAgent
+from .router_agent import RouterAgent
 
-__all__ = ["ClassifierAgent", "ApiValidatorAgent", "IssueInsightsAgent"]
+__all__ = ["ClassifierAgent", "ApiValidatorAgent", "IssueInsightsAgent", "RouterAgent"]
 

--- a/src/agents/router_agent.py
+++ b/src/agents/router_agent.py
@@ -1,0 +1,94 @@
+"""Router agent that directs questions to the appropriate workflow."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+from src.configs.config import load_config
+from src.agents.classifier import ClassifierAgent
+from src.agents.issue_insights import IssueInsightsAgent
+from src.agents.api_validator import ApiValidatorAgent
+from src.prompts import load_prompt
+from src.services.jira_service import get_issue_by_id_tool
+from src.utils import safe_format
+
+logger = logging.getLogger(__name__)
+logger.debug("router_agent module loaded")
+
+
+class RouterAgent:
+    """Agent that routes questions to insights or validation workflows."""
+
+    def __init__(self, config_path: str | None = None) -> None:
+        logger.debug("Initializing RouterAgent with config_path=%s", config_path)
+        self.config = load_config(config_path)
+        self.classifier = ClassifierAgent(config_path)
+        self.validator = ApiValidatorAgent(config_path)
+        self.insights = IssueInsightsAgent(config_path)
+        if self.config.projects:
+            pattern = "|".join(re.escape(p) for p in self.config.projects)
+        else:
+            pattern = r"[A-Za-z][A-Za-z0-9]+"
+        self.issue_re = re.compile(rf"(?:{pattern})-\d+", re.IGNORECASE)
+        self.router_prompt = load_prompt("router.txt")
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _extract_issue_id(self, text: str) -> str | None:
+        match = self.issue_re.search(text)
+        if match:
+            issue_id = match.group(0).upper()
+            logger.debug("Extracted issue id %s from text", issue_id)
+            return issue_id
+        logger.warning("No issue id found in text: %s", text)
+        return None
+
+    def _should_validate(self, question: str, **kwargs: Any) -> bool:
+        if self.router_prompt:
+            prompt = safe_format(self.router_prompt, {"question": question})
+        else:
+            prompt = f"Is this question asking for API validation? {question}"
+        label = self.classifier.classify(prompt, **kwargs)
+        result = str(label).strip().upper().startswith("VALIDATE")
+        logger.debug("Should validate: %s (label=%s)", result, label)
+        return result
+
+    def _classify_and_validate(self, issue_id: str, **kwargs: Any) -> str:
+        logger.info("Running classification/validation flow for %s", issue_id)
+        issue_json = get_issue_by_id_tool.run(issue_id)
+        issue = json.loads(issue_json)
+        fields = issue.get("fields", {})
+        prompt = safe_format(
+            load_prompt("classifier.txt"),
+            {
+                "summary": fields.get("summary", ""),
+                "description": fields.get("description", ""),
+            },
+        )
+        label = self.classifier.classify(prompt, **kwargs)
+        logger.debug("Classifier label: %s", label)
+        if str(label).upper().startswith("API"):
+            return self.validator.validate(issue, **kwargs)
+        return "Issue not API related"
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def ask(self, question: str, **kwargs: Any) -> str:
+        """Route ``question`` to the appropriate workflow."""
+        logger.info("Router received question: %s", question)
+        issue_id = self._extract_issue_id(question)
+        if not issue_id:
+            return "No Jira ticket found in question"
+
+        if self._should_validate(question, **kwargs):
+            return self._classify_and_validate(issue_id, **kwargs)
+
+        return self.insights.ask(issue_id, question, **kwargs)
+
+
+__all__ = ["RouterAgent"]

--- a/src/configs/config.py
+++ b/src/configs/config.py
@@ -17,6 +17,7 @@ class Config:
     openai_model: str
     anthropic_api_key: str
     anthropic_model: str
+    projects: list[str]
 
 
 def setup_logging(config: "Config") -> None:
@@ -60,4 +61,5 @@ def load_config(path: str = None) -> Config:
         openai_model=os.getenv("OPENAI_MODEL", data.get("openai_model", "gpt-3.5-turbo")),
         anthropic_api_key=os.getenv("ANTHROPIC_API_KEY", data.get("anthropic_api_key", "")),
         anthropic_model=os.getenv("ANTHROPIC_MODEL", data.get("anthropic_model", "claude-3-opus")),
+        projects=[p.strip().upper() for p in os.getenv("PROJECTS", ",".join(data.get("projects", []))).split(",") if p.strip()] or [],
     )

--- a/src/configs/config.yml
+++ b/src/configs/config.yml
@@ -4,3 +4,7 @@ debug: true
 base_llm: openai
 openai_model: gpt-3.5-turbo
 anthropic_model: claude-3-opus
+projects:
+  - RB
+  - SD
+  - RA

--- a/src/prompts/router.txt
+++ b/src/prompts/router.txt
@@ -1,0 +1,2 @@
+You are a routing assistant deciding whether a question is requesting API validation or general issue insights. Respond with only "VALIDATE" if the user wants the issue validated. Respond with "INSIGHT" otherwise.
+Question: {question}


### PR DESCRIPTION
## Summary
- add new `RouterAgent` capable of routing questions to either issue insights or API validation
- export RouterAgent from the agents package
- router now uses an LLM prompt to decide when validation is required
- configurable project list for issue ID extraction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6846aae5fa2c8328b729c2b42858f08b