### PR TITLE
Add config flag for body output

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ JIRA_API_TOKEN=your-api-token
 OPENAI_API_KEY=your-openai-api-key
 OPENAI_MODEL=gpt-4o-mini
 BASE_LLM=openai  # or 'anthropic'
+INCLUDE_WHOLE_API_BODY=false
 ```
 
-The default model and provider can be changed in `src/configs/config.yml` or by setting `OPENAI_MODEL` and `BASE_LLM` in the environment.
+The default model and provider can be changed in `src/configs/config.yml` or by setting `OPENAI_MODEL` and `BASE_LLM` in the environment. The flag `INCLUDE_WHOLE_API_BODY` controls whether validation prompts should return the full API bodies or only boolean indicators of their validity.
 
 ## Usage
 

--- a/src/agents/api_validator.py
+++ b/src/agents/api_validator.py
@@ -71,6 +71,10 @@ class ApiValidatorAgent:
             "summary": extract_plain_text(fields.get("summary")),
             "description": extract_plain_text(fields.get("description")),
             "status": status,
+            "body_instructions": (
+                "Include full request and response bodies" if self.config.include_whole_api_body
+                else "Do not include full bodies. Provide boolean fields `request_body_exists`, `request_body_valid`, `response_body_exists`, and `response_body_valid` and set the example fields to null."
+            ),
         }
         try:
             prompt = safe_format(template, values)

--- a/src/configs/config.py
+++ b/src/configs/config.py
@@ -18,6 +18,7 @@ class Config:
     anthropic_api_key: str
     anthropic_model: str
     projects: list[str]
+    include_whole_api_body: bool
 
 
 def setup_logging(config: "Config") -> None:
@@ -62,4 +63,5 @@ def load_config(path: str = None) -> Config:
         anthropic_api_key=os.getenv("ANTHROPIC_API_KEY", data.get("anthropic_api_key", "")),
         anthropic_model=os.getenv("ANTHROPIC_MODEL", data.get("anthropic_model", "claude-3-opus")),
         projects=[p.strip().upper() for p in os.getenv("PROJECTS", ",".join(data.get("projects", []))).split(",") if p.strip()] or [],
+        include_whole_api_body=_env_bool("INCLUDE_WHOLE_API_BODY", data.get("include_whole_api_body", False)),
     )

--- a/src/configs/config.yml
+++ b/src/configs/config.yml
@@ -8,3 +8,4 @@ projects:
   - RB
   - SD
   - RA
+include_whole_api_body: false

--- a/src/prompts/api_validator.txt
+++ b/src/prompts/api_validator.txt
@@ -11,6 +11,7 @@ ReadyforVerification: |
       (agents, clients, offices, employees, insurers, banks, experts, creditors and sales channels). 
       The result contains details for their role according to the filter criteria provided in the query parameters."
   4. Parse the "Summary" and "Description." Ignore Jira-specific color tags or images unless they carry URLs or JSON blocks.
+  {body_instructions}
   5. Return exactly one JSON object (no extra commentary) according to the schema below.
   
   **Output JSON Schema:**
@@ -23,10 +24,14 @@ ReadyforVerification: |
       "swagger_url": "string or null",
       "method": "POST" | "GET" | "PUT" | "DELETE" | null,
       "api_url": "string or null",
-      "request_body_example": {{ ... }} | null,
-      "response_example": {{ ... }} | null,
+        "request_body_exists": true | false,
+        "request_body_valid": true | false,
+        "response_body_exists": true | false,
+        "response_body_valid": true | false,
+        "request_body_example": {{ ... }} | null,
+        "response_example": {{ ... }} | null,
     }},
-    "jira_comment": "Natural-language summary of missing or malformed fields with specific example suggestions, appropriate to the development status."
+    "jira_comment": "Natural-language summary of missing or malformed fields with specific example suggestions, appropriate to the development status. If the request body exists but is invalid, mention it."
     }}
     ```
 
@@ -46,6 +51,7 @@ Backlog: |
       (agents, clients, offices, employees, insurers, banks, experts, creditors and sales channels). 
       The result contains details for their role according to the filter criteria provided in the query parameters."
   4. Parse the "Summary" and "Description." Ignore Jira-specific color tags or images unless they carry URLs or JSON blocks.
+  {body_instructions}
   5. Return exactly one JSON object (no extra commentary) according to the schema below.
   
   **Output JSON Schema:**
@@ -58,10 +64,14 @@ Backlog: |
       "swagger_url": "string or null",
       "method": "POST" | "GET" | "PUT" | "DELETE" | null,
       "api_url": "string or null",
-      "request_body_example": {{ ... }} | null,
-      "response_example": {{ ... }} | null,
+        "request_body_exists": true | false,
+        "request_body_valid": true | false,
+        "response_body_exists": true | false,
+        "response_body_valid": true | false,
+        "request_body_example": {{ ... }} | null,
+        "response_example": {{ ... }} | null,
     }},
-    "jira_comment": "Natural-language summary of missing or malformed fields with specific example suggestions, appropriate to the development status."
+    "jira_comment": "Natural-language summary of missing or malformed fields with specific example suggestions, appropriate to the development status. If the request body exists but is invalid, mention it."
     }}
     ```
 
@@ -83,6 +93,7 @@ InDevelopment: |
       - If it’s a GET or DELETE, explicitly set `"request_body_example": null`..
         **Instructions:**
   - Parse the "Summary" and "Description." Ignore Jira-specific color tags or images unless they carry URLs or JSON blocks.
+  {body_instructions}
   - Return exactly one JSON object (no extra commentary) according to the schema below.
 
   **Output JSON Schema:**
@@ -94,8 +105,12 @@ InDevelopment: |
       "swagger_url": "string or null",
       "method": "POST" | "GET" | "PUT" | "DELETE" | null,
       "api_url": "string or null",
-      "request_body_example": {{ ... }} | null,
-      "response_example": {{ ... }} | null
+        "request_body_exists": true | false,
+        "request_body_valid": true | false,
+        "response_body_exists": true | false,
+        "response_body_valid": true | false,
+        "request_body_example": {{ ... }} | null,
+        "response_example": {{ ... }} | null
     }}
   }}
   ```
@@ -129,6 +144,7 @@ Done: |
 
   **Instructions:**
   - Parse the "Summary" and "Description." Ignore Jira-specific color tags or images unless they carry URLs or JSON blocks.
+  {body_instructions}
   - Because the status is "Done," every required field must be valid. If a field is missing or inconsistent, set it to `null` and list a clear error.
   - For consistency against Swagger, you may assume the model can "fetch" or "know" the spec details when you include the URL. If you cannot verify programmatically, simply state in errors "Swagger check could not be completed."
   - Return exactly one JSON object (no extra commentary) according to the schema below.
@@ -142,8 +158,12 @@ Done: |
       "swagger_url": "string or null",
       "method": "POST" | "GET" | "PUT" | "DELETE" | null,
       "api_url": "string or null",
-      "request_body_example": {{ ... }} | null,
-      "response_example": {{ ... }} | null
+        "request_body_exists": true | false,
+        "request_body_valid": true | false,
+        "response_body_exists": true | false,
+        "response_body_valid": true | false,
+        "request_body_example": {{ ... }} | null,
+        "response_example": {{ ... }} | null
     }}
   }}
   ```


### PR DESCRIPTION
## Summary
- add `include_whole_api_body` option to configuration
- document new environment variable in README
- update API validator prompts with `body_instructions` placeholder and boolean fields
- teach `ApiValidatorAgent` to insert instructions based on config

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_b_6846b07cb8f083289ed8cc587f981cc2