### PR TITLE
Improve router logging and interactive loop

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,16 +33,22 @@ def get_jira_client():
 
 def main() -> None:
     logger.info("Starting main interaction loop")
-    question = input("Enter your question: ").strip()
 
     logger.debug("Instantiating RouterAgent")
     router = RouterAgent()
 
-    try:
-        answer = router.ask(question)
-        logger.info("Agent response: %s", answer)
-    except Exception:
-        logger.exception("Error processing question")
+    while True:
+        question = input("Enter your question (type 'exit' to quit): ").strip()
+        if question.lower() == "exit":
+            logger.info("Exiting interaction loop")
+            break
+
+        try:
+            answer = router.ask(question)
+            logger.info("Agent response: %s", answer)
+            print(answer)
+        except Exception:
+            logger.exception("Error processing question")
 
 
 if __name__ == "__main__":

--- a/src/agents/router_agent.py
+++ b/src/agents/router_agent.py
@@ -86,8 +86,10 @@ class RouterAgent:
             return "No Jira ticket found in question"
 
         if self._should_validate(question, **kwargs):
+            logger.info("Routing to validation workflow")
             return self._classify_and_validate(issue_id, **kwargs)
 
+        logger.info("Routing to general insights workflow")
         return self.insights.ask(issue_id, question, **kwargs)
 
 


### PR DESCRIPTION
## Summary
- improve `main.py` so the script keeps asking questions until `exit` is typed
- log whether questions are routed for validation or general issue insights

## Testing
- `python -m py_compile main.py src/agents/router_agent.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6846b30057788328ac31503f2898b502