### PR TITLE
Add langchain debug config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ OPENAI_API_KEY=your-openai-api-key
 OPENAI_MODEL=gpt-4o-mini
 BASE_LLM=openai  # or 'anthropic'
 INCLUDE_WHOLE_API_BODY=false
+LANGCHAIN_DEBUG=false
 ```
 
 The default model and provider can be changed in `src/configs/config.yml` or by setting `OPENAI_MODEL` and `BASE_LLM` in the environment. The flag `INCLUDE_WHOLE_API_BODY` controls whether validation prompts should return the full API bodies or only boolean indicators of their validity.
 
 ### Debug Logging
 
-When `DEBUG=true` the application configures colored output using `rich`. Any tracebacks will also be displayed with syntax highlighting. The utility class `RichLogger` can be passed as a callback to LangChain components for detailed, step-by-step logs.
+When `DEBUG=true` the application configures colored output using `rich`. Any tracebacks will also be displayed with syntax highlighting. The utility class `RichLogger` can be passed as a callback to LangChain components for detailed, step-by-step logs. Set `LANGCHAIN_DEBUG=true` to enable verbose logs from LangChain itself.
 
 ## Usage
 

--- a/main.py
+++ b/main.py
@@ -19,9 +19,6 @@ load_dotenv(override=True)
 # Load application configuration and configure logging
 config = load_config()
 setup_logging(config)
-if langchain:
-    langchain.debug = config.debug
-
 
 def get_jira_client():
     """Return a JiraClient instance using environment variables from .env file."""

--- a/src/configs/config.py
+++ b/src/configs/config.py
@@ -27,6 +27,7 @@ class Config:
     anthropic_model: str
     projects: list[str]
     include_whole_api_body: bool
+    langchain_debug: bool
 
 
 def setup_logging(config: "Config") -> None:
@@ -45,6 +46,13 @@ def setup_logging(config: "Config") -> None:
             format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         )
     logger.debug("Logging initialized at level %s", logging.getLevelName(level))
+    try:
+        import langchain
+
+        langchain.debug = config.langchain_debug
+        logger.debug("LangChain debug mode set to %s", config.langchain_debug)
+    except Exception:
+        logger.debug("LangChain not installed; skipping debug configuration")
 
 
 def load_config(path: str = None) -> Config:
@@ -80,4 +88,5 @@ def load_config(path: str = None) -> Config:
         anthropic_model=os.getenv("ANTHROPIC_MODEL", data.get("anthropic_model", "claude-3-opus")),
         projects=[p.strip().upper() for p in os.getenv("PROJECTS", ",".join(data.get("projects", []))).split(",") if p.strip()] or [],
         include_whole_api_body=_env_bool("INCLUDE_WHOLE_API_BODY", data.get("include_whole_api_body", False)),
+        langchain_debug=_env_bool("LANGCHAIN_DEBUG", data.get("langchain_debug", False)),
     )

--- a/src/configs/config.yml
+++ b/src/configs/config.yml
@@ -9,3 +9,4 @@ projects:
   - SD
   - RA
 include_whole_api_body: false
+langchain_debug: false


### PR DESCRIPTION
## Summary
- allow configuration of `langchain.debug` via `langchain_debug` option
- set the value inside `setup_logging`
- remove the direct assignment from `main.py`
- document `LANGCHAIN_DEBUG` environment variable

## Testing
- `python -m compileall -q src main.py`

------
https://chatgpt.com/codex/tasks/task_b_6846b76545488328b0957d15f17ea0be