### PR TITLE
Add configurable rich logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,19 @@ OPENAI_MODEL=gpt-4o-mini
 BASE_LLM=openai  # or 'anthropic'
 INCLUDE_WHOLE_API_BODY=false
 LANGCHAIN_DEBUG=false
+RICH_LOGGING=true
 ```
 
 The default model and provider can be changed in `src/configs/config.yml` or by setting `OPENAI_MODEL` and `BASE_LLM` in the environment. The flag `INCLUDE_WHOLE_API_BODY` controls whether validation prompts should return the full API bodies or only boolean indicators of their validity.
 
 ### Debug Logging
 
-When `DEBUG=true` the application configures colored output using `rich`. Any tracebacks will also be displayed with syntax highlighting. The utility class `RichLogger` can be passed as a callback to LangChain components for detailed, step-by-step logs. Set `LANGCHAIN_DEBUG=true` to enable verbose logs from LangChain itself.
+When `DEBUG=true` the log level is set to ``DEBUG``. Colored output using the
+`rich` library can be toggled with `RICH_LOGGING` (defaults to `true`). Any
+tracebacks will also be displayed with syntax highlighting when rich logging is
+enabled. The utility class `RichLogger` can be passed as a callback to LangChain
+components for detailed, step-by-step logs. Set `LANGCHAIN_DEBUG=true` to enable
+verbose logs from LangChain itself.
 
 ## Usage
 

--- a/src/configs/config.py
+++ b/src/configs/config.py
@@ -28,12 +28,14 @@ class Config:
     projects: list[str]
     include_whole_api_body: bool
     langchain_debug: bool
+    rich_logging: bool
 
 
 def setup_logging(config: "Config") -> None:
     """Configure logging level based on ``config.debug``."""
     level = logging.DEBUG if config.debug else logging.INFO
-    if RichHandler:
+    use_rich = config.rich_logging and RichHandler is not None
+    if use_rich:
         install_rich_traceback()
         logging.basicConfig(
             level=level,
@@ -89,4 +91,5 @@ def load_config(path: str = None) -> Config:
         projects=[p.strip().upper() for p in os.getenv("PROJECTS", ",".join(data.get("projects", []))).split(",") if p.strip()] or [],
         include_whole_api_body=_env_bool("INCLUDE_WHOLE_API_BODY", data.get("include_whole_api_body", False)),
         langchain_debug=_env_bool("LANGCHAIN_DEBUG", data.get("langchain_debug", False)),
+        rich_logging=_env_bool("RICH_LOGGING", data.get("rich_logging", True)),
     )

--- a/src/configs/config.yml
+++ b/src/configs/config.yml
@@ -1,6 +1,7 @@
 app_name: VirtualLibrary
 environment: development
 debug: true
+rich_logging: true
 base_llm: openai
 openai_model: gpt-3.5-turbo
 anthropic_model: claude-3-opus


### PR DESCRIPTION
## Summary
- make use of `rich` optional with `rich_logging` flag
- document new `RICH_LOGGING` environment variable

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6846b83b36dc832894323589ece9a9a4