### PR TITLE
Add basic FastAPI server

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,14 @@ python agent.py "List the issue details for PROJ-1"
 ```
 
 These examples require valid API keys for both OpenAI and Jira when using the respective features.
+
+### FastAPI Server
+
+A minimal FastAPI application is included to expose the assistant over HTTP. Start the server with:
+
+```bash
+uvicorn app:app --reload
+```
+
+The `/ask` endpoint accepts a JSON payload containing a `question` field and returns the answer from the `RouterAgent`.
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,32 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+import logging
+
+from src.configs import load_config, setup_logging
+from src.agents.router_agent import RouterAgent
+
+config = load_config()
+setup_logging(config)
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="Jira AI Assistant")
+router_agent = RouterAgent()
+
+class QuestionRequest(BaseModel):
+    question: str
+
+class AnswerResponse(BaseModel):
+    answer: str
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Simple healthcheck endpoint"""
+    return {"status": "ok"}
+
+@app.post("/ask", response_model=AnswerResponse)
+def ask(req: QuestionRequest) -> AnswerResponse:
+    """Return the assistant answer for a question."""
+    logger.info("Received question via API: %s", req.question)
+    answer = router_agent.ask(req.question)
+    return AnswerResponse(answer=answer)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ requests
 gradio
 jira
 rich
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- expose RouterAgent through a FastAPI server
- document FastAPI usage
- include FastAPI and uvicorn dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6846be3cff0c83289843026328ab1478