### PR TITLE
Add Jira payload stripping option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,15 @@ BASE_LLM=openai  # or 'anthropic'
 INCLUDE_WHOLE_API_BODY=false
 LANGCHAIN_DEBUG=false
 RICH_LOGGING=true
+STRIP_UNUSED_JIRA_DATA=true
 ```
 
 The default model and provider can be changed in `src/configs/config.yml` or by setting `OPENAI_MODEL` and `BASE_LLM` in the environment. The flag `INCLUDE_WHOLE_API_BODY` controls whether validation prompts should return the full API bodies or only boolean indicators of their validity.
 
+
 Conversation memory can be enabled with `conversation_memory: true` in the same file. The number of previous questions remembered defaults to three and can be adjusted via `max_questions_to_remember`. When LangChain is available the agent uses a `ConversationBufferWindowMemory` of size `k`. If `k` is greater than three the buffer is combined with `ConversationSummaryMemory` so older turns are summarized automatically. When the limit is reached you'll be prompted to start a new conversation.
+
+Set `strip_unused_jira_data: true` in the config to remove avatar URLs and ID fields from Jira payloads for more concise outputs.
 
 ### Debug Logging
 

--- a/src/configs/config.py
+++ b/src/configs/config.py
@@ -31,6 +31,7 @@ class Config:
     rich_logging: bool
     conversation_memory: bool
     max_questions_to_remember: int
+    strip_unused_jira_data: bool
 
 
 def setup_logging(config: "Config") -> None:
@@ -105,4 +106,5 @@ def load_config(path: str = None) -> Config:
         rich_logging=_env_bool("RICH_LOGGING", data.get("rich_logging", True)),
         conversation_memory=_env_bool("CONVERSATION_MEMORY", data.get("conversation_memory", False)),
         max_questions_to_remember=_env_int("MAX_NUMBER_OF_QUESTIONS_TO_REMEMBER", data.get("max_questions_to_remember", 3)),
+        strip_unused_jira_data=_env_bool("STRIP_UNUSED_JIRA_DATA", data.get("strip_unused_jira_data", False)),
     )

--- a/src/configs/config.yml
+++ b/src/configs/config.yml
@@ -13,3 +13,4 @@ include_whole_api_body: false
 langchain_debug: false
 conversation_memory: false
 max_questions_to_remember: 3
+strip_unused_jira_data: true

--- a/src/jira_client.py
+++ b/src/jira_client.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List
 
-from src.utils import JiraUtils
+from src.utils import JiraUtils, strip_unused_jira_data, strip_nulls
 
 from jira import JIRA
 import logging
@@ -11,50 +11,57 @@ logger = logging.getLogger(__name__)
 class JiraClient:
     """Wrapper around the official ``jira`` client exposing common helpers."""
 
-    def __init__(self, base_url: str, email: str, api_token: str) -> None:
+    def __init__(self, base_url: str, email: str, api_token: str, *, strip_unused_payload: bool = False) -> None:
         logger.debug("Initializing JiraClient with base_url=%s email=%s", base_url, email)
         self._jira = JIRA(server=base_url.rstrip('/'), basic_auth=(email, api_token))
+        self._strip_unused = strip_unused_payload
 
     def get_issue(self, issue_key: str, expand: str | None = None) -> Dict[str, Any]:
         """Retrieve an issue by its key."""
         logger.debug("Fetching issue %s", issue_key)
         issue = self._jira.issue(issue_key, expand=expand)
-        return JiraUtils.clean_issue(issue.raw)
+        return JiraUtils.clean_issue(issue.raw, strip_unused=self._strip_unused)
 
     def create_issue(self, fields: Dict[str, Any]) -> Dict[str, Any]:
         """Create a new issue and return its raw representation."""
         logger.debug("Creating issue with fields: %s", fields)
         issue = self._jira.create_issue(fields=fields)
-        return JiraUtils.clean_issue(issue.raw)
+        return JiraUtils.clean_issue(issue.raw, strip_unused=self._strip_unused)
 
     def add_comment(self, issue_key: str, comment: str) -> Dict[str, Any]:
         """Add a comment to an issue and return the created comment."""
         logger.debug("Adding comment to issue %s", issue_key)
         cmt = self._jira.add_comment(issue_key, comment)
-        return cmt.raw
+        data = strip_nulls(cmt.raw)
+        if self._strip_unused:
+            data = strip_unused_jira_data(data)
+        return data
 
     def get_comments(self, issue_key: str) -> List[Dict[str, Any]]:
         """Return comments for an issue."""
         logger.debug("Fetching comments for issue %s", issue_key)
         comments = self._jira.comments(issue_key)
-        return [c.raw for c in comments]
+        cleaned = [strip_nulls(c.raw) for c in comments]
+        if self._strip_unused:
+            cleaned = [strip_unused_jira_data(c) for c in cleaned]
+        return cleaned
 
     def update_issue(self, issue_key: str, fields: Dict[str, Any]) -> Dict[str, Any]:
         """Update fields of an issue."""
         logger.debug("Updating issue %s with fields: %s", issue_key, fields)
         issue = self._jira.issue(issue_key)
         issue.update(fields=fields)
-        return JiraUtils.clean_issue(issue.raw)
+        return JiraUtils.clean_issue(issue.raw, strip_unused=self._strip_unused)
 
     def get_changelog(self, issue_key: str) -> Dict[str, Any]:
         """Return cleaned changelog for an issue."""
         logger.debug("Fetching changelog for issue %s", issue_key)
         issue = self._jira.issue(issue_key, expand="changelog")
         history = issue.raw.get("changelog", {})
-        return JiraUtils.clean_history(history)
+        return JiraUtils.clean_history(history, strip_unused=self._strip_unused)
 
     def search_issues(self, jql: str, **kwargs: Any) -> List[Dict[str, Any]]:
         """Run a JQL query and return the matching issues."""
         logger.debug("Searching issues with JQL: %s", jql)
         issues = self._jira.search_issues(jql, **kwargs)
-        return [JiraUtils.clean_issue(iss.raw) for iss in issues]
+        return [JiraUtils.clean_issue(iss.raw, strip_unused=self._strip_unused) for iss in issues]

--- a/src/services/jira_service.py
+++ b/src/services/jira_service.py
@@ -5,6 +5,7 @@ from typing import Dict, Any
 from langchain.tools import Tool
 
 from src.jira_client import JiraClient
+from src.configs.config import load_config
 import logging
 
 logger = logging.getLogger(__name__)
@@ -12,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 def _get_jira_client() -> JiraClient:
     """Instantiate a :class:`JiraClient` using environment variables."""
+    cfg = load_config()
     base_url = os.getenv("JIRA_BASE_URL")
     email = os.getenv("JIRA_EMAIL")
     token = os.getenv("JIRA_API_TOKEN")
@@ -21,7 +23,7 @@ def _get_jira_client() -> JiraClient:
         )
     logger.debug("Creating JiraClient for base_url=%s email=%s", base_url, email)
     logger.info("JiraClient initialized for %s", base_url)
-    return JiraClient(base_url, email, token)
+    return JiraClient(base_url, email, token, strip_unused_payload=cfg.strip_unused_jira_data)
 
 
 # --- Tool for getting issue details by ID ---

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,7 +1,14 @@
 """Utility helpers for the Jira AI Assistant."""
 
-from .jira import extract_plain_text, JiraUtils, strip_nulls
+from .jira import extract_plain_text, JiraUtils, strip_nulls, strip_unused_jira_data
 from .prompt import safe_format
 from .rich_logger import RichLogger
 
-__all__ = ["extract_plain_text", "strip_nulls", "JiraUtils", "safe_format", "RichLogger"]
+__all__ = [
+    "extract_plain_text",
+    "strip_nulls",
+    "strip_unused_jira_data",
+    "JiraUtils",
+    "safe_format",
+    "RichLogger",
+]


### PR DESCRIPTION
## Summary
- add `strip_unused_jira_data` setting to configuration
- trim avatar URLs and ID fields from Jira data when enabled
- respect the new setting when creating the Jira client
- document option in README

## Testing
- `python -m py_compile src/configs/config.py src/utils/jira.py src/utils/__init__.py src/jira_client.py src/services/jira_service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6846d68a9d508328a3b7db6f8ffad34b