### PR TITLE
Add simple context memory utility

### DIFF
--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -3,6 +3,7 @@
 from .jira import extract_plain_text, JiraUtils, strip_nulls, strip_unused_jira_data
 from .prompt import safe_format
 from .rich_logger import RichLogger
+from .context_memory import JiraContextMemory
 
 __all__ = [
     "extract_plain_text",
@@ -11,4 +12,5 @@ __all__ = [
     "JiraUtils",
     "safe_format",
     "RichLogger",
+    "JiraContextMemory",
 ]

--- a/src/utils/context_memory.py
+++ b/src/utils/context_memory.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Lightweight memory for tracking the current Jira issue in a conversation."""
+
+from typing import Dict, Any, Optional, List
+import re
+
+try:
+    from langchain.memory import BaseMemory
+except Exception:  # pragma: no cover - langchain optional
+    BaseMemory = object  # type: ignore[misc, assignment]
+
+
+class JiraContextMemory(BaseMemory):
+    """Simple conversation memory keeping track of a Jira issue id."""
+
+    def __init__(self) -> None:
+        self.current_issue: Optional[str] = None
+        self.chat_history: List[str] = []
+
+    # ------------------------------------------------------------------
+    # BaseMemory API
+    # ------------------------------------------------------------------
+    @property
+    def memory_variables(self) -> list[str]:
+        return ["current_issue", "chat_history"]
+
+    def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
+        """Return stored variables for prompt formatting."""
+        return {
+            "current_issue": self.current_issue or "",
+            "chat_history": "\n".join(self.chat_history),
+        }
+
+    def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
+        """Update memory based on the latest interaction."""
+        input_text = inputs.get("input", "")
+        output_text = outputs.get("output", "")
+
+        found_key = self.extract_jira_key(input_text)
+        if found_key:
+            self.current_issue = found_key
+
+        if "forget" in input_text.lower():
+            self.current_issue = None
+
+        self.chat_history.append(f"Human: {input_text}")
+        self.chat_history.append(f"AI: {output_text}")
+
+    def clear(self) -> None:
+        """Reset memory state."""
+        self.current_issue = None
+        self.chat_history = []
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def extract_jira_key(text: str) -> Optional[str]:
+        match = re.search(r"\b[A-Z]+-\d+\b", text)
+        return match.group(0) if match else None
+
+
+__all__ = ["JiraContextMemory"]


### PR DESCRIPTION
## Summary
- implement `JiraContextMemory` for lightweight conversation state
- export `JiraContextMemory` from `utils`

## Testing
- `pytest -q`
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement openai)*

------
https://chatgpt.com/codex/tasks/task_b_6846dafb5810832891f61b7583a6d03d