### PR TITLE
Add timestamp system message

### DIFF
--- a/src/agents/issue_insights.py
+++ b/src/agents/issue_insights.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from typing import Any, Dict
+from datetime import datetime
 
 from src.configs.config import load_config
 from src.llm_clients.openai_client import OpenAIClient
@@ -96,7 +97,11 @@ class IssueInsightsAgent:
             )
         values = {"issue": issue_json, "history": history_json, "question": question}
         prompt = safe_format(prompt_template, values)
-        messages = (history or []) + [{"role": "user", "content": prompt}]
+        system_msg = {
+            "role": "system",
+            "content": f"Current date and time: {datetime.now().isoformat()}",
+        }
+        messages = [system_msg] + (history or []) + [{"role": "user", "content": prompt}]
         response = self.client.chat_completion(messages, **kwargs)
         try:
             return response.choices[0].message.content.strip()


### PR DESCRIPTION
## Summary
- include `datetime.now` import in issue insights agent
- prepend a system message with the current timestamp for each issue insights request

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846e1ac60448328ac77a19392da97a6