### PR TITLE
Add related Jira fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ INCLUDE_WHOLE_API_BODY=false
 LANGCHAIN_DEBUG=false
 RICH_LOGGING=true
 STRIP_UNUSED_JIRA_DATA=true
+FOLLOW_RELATED_JIRAS=false
 ```
 
 The default model and provider can be changed in `src/configs/config.yml` or by setting `OPENAI_MODEL` and `BASE_LLM` in the environment. The flag `INCLUDE_WHOLE_API_BODY` controls whether validation prompts should return the full API bodies or only boolean indicators of their validity.
@@ -31,6 +32,7 @@ Conversation memory can be enabled with `conversation_memory: true` in the same 
 The assistant also remembers the last Jira key you referenced. Follow-up questions can omit the key and it will use the stored value. Include the word `forget` in your message to clear this memory.
 
 Set `strip_unused_jira_data: true` in the config to remove avatar URLs and ID fields from Jira payloads for more concise outputs.
+Set `follow_related_jiras: true` to automatically fetch and summarize linked issues and subtasks when answering questions.
 
 ### Debug Logging
 

--- a/src/configs/config.py
+++ b/src/configs/config.py
@@ -32,6 +32,7 @@ class Config:
     conversation_memory: bool
     max_questions_to_remember: int
     strip_unused_jira_data: bool
+    follow_related_jiras: bool
 
 
 def setup_logging(config: "Config") -> None:
@@ -107,4 +108,5 @@ def load_config(path: str = None) -> Config:
         conversation_memory=_env_bool("CONVERSATION_MEMORY", data.get("conversation_memory", False)),
         max_questions_to_remember=_env_int("MAX_NUMBER_OF_QUESTIONS_TO_REMEMBER", data.get("max_questions_to_remember", 3)),
         strip_unused_jira_data=_env_bool("STRIP_UNUSED_JIRA_DATA", data.get("strip_unused_jira_data", False)),
+        follow_related_jiras=_env_bool("FOLLOW_RELATED_JIRAS", data.get("follow_related_jiras", False)),
     )

--- a/src/configs/config.yml
+++ b/src/configs/config.yml
@@ -14,3 +14,4 @@ langchain_debug: true
 conversation_memory: true
 max_questions_to_remember: 3
 strip_unused_jira_data: true
+follow_related_jiras: false

--- a/src/prompts/issue_insights.txt
+++ b/src/prompts/issue_insights.txt
@@ -1,4 +1,5 @@
 You are a Jira assistant. Given the issue details and change history below, answer the user's question.
 Issue JSON:\n{issue}\n
 History JSON:\n{history}\n
+Related Issues:\n{related}\n
 Question: {question}

--- a/src/services/jira_service.py
+++ b/src/services/jira_service.py
@@ -121,6 +121,23 @@ get_issue_history_tool = Tool(
     ),
 )
 
+# --- Tool for fetching subtasks and linked issues ---
+
+def get_related_issues_func(issue_id: str) -> str:
+    """Return subtasks and linked issues for the given ticket."""
+    logger.debug("Fetching related issues for %s", issue_id)
+    client = _get_jira_client()
+    related = client.get_related_issues(issue_id)
+    logger.info("Fetched related issues for %s", issue_id)
+    return json.dumps(related)
+
+
+get_related_issues_tool = Tool(
+    name="get_related_issues",
+    func=get_related_issues_func,
+    description="Return linked issues and subtasks for a Jira issue key as JSON.",
+)
+
 # --- Tool for adding a comment to an issue ---
 
 def add_comment_to_issue_func(issue_id: str, comment: str) -> str:
@@ -171,6 +188,7 @@ jira_tools = [
     create_jira_issue_tool,
     get_issue_comments_tool,
     get_issue_history_tool,
+    get_related_issues_tool,
     add_comment_to_issue_tool,
     update_issue_fields_tool,
 ]
@@ -180,6 +198,7 @@ __all__ = [
     "create_jira_issue_tool",
     "get_issue_comments_tool",
     "get_issue_history_tool",
+    "get_related_issues_tool",
     "add_comment_to_issue_tool",
     "update_issue_fields_tool",
     "jira_tools",


### PR DESCRIPTION
## Summary
- allow following related Jiras via `follow_related_jiras` config
- fetch linked issues and subtasks in `JiraClient`
- expose `get_related_issues` tool
- show related issue summaries when enabled
- document new option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6846e522ae948328bf601fd124b534a9