### PR TITLE
Refactor LLM client init

### DIFF
--- a/src/agents/api_validator.py
+++ b/src/agents/api_validator.py
@@ -10,8 +10,7 @@ import yaml
 from src.prompts import load_prompt
 from src.utils import extract_plain_text, safe_format
 from src.configs.config import load_config
-from src.llm_clients.openai_client import OpenAIClient
-from src.llm_clients.claude_client import ClaudeClient
+from src.llm_clients import create_llm_client
 
 logger = logging.getLogger(__name__)
 logger.debug("api_validator module loaded")
@@ -42,16 +41,7 @@ class ApiValidatorAgent:
     def __init__(self, config_path: str | None = None) -> None:
         logger.debug("Initializing ApiValidatorAgent with config_path=%s", config_path)
         self.config = load_config(config_path)
-        llm = self.config.base_llm.lower()
-        if llm == "openai":
-            logger.debug("Using OpenAIClient")
-            self.client = OpenAIClient(config_path)
-        elif llm in {"anthropic", "claude"}:
-            logger.debug("Using ClaudeClient")
-            self.client = ClaudeClient(config_path)
-        else:
-            logger.error("Unsupported LLM provider: %s", self.config.base_llm)
-            raise ValueError(f"Unsupported LLM provider: {self.config.base_llm}")
+        self.client = create_llm_client(config_path)
 
         self.prompts = _load_status_prompts()
 

--- a/src/agents/classifier.py
+++ b/src/agents/classifier.py
@@ -4,8 +4,7 @@ from typing import List, Dict, Any
 import logging
 
 from src.configs.config import load_config
-from src.llm_clients.openai_client import OpenAIClient
-from src.llm_clients.claude_client import ClaudeClient
+from src.llm_clients import create_llm_client
 from src.services.jira_service import get_issue_by_id_tool
 
 logger = logging.getLogger(__name__)
@@ -18,17 +17,7 @@ class ClassifierAgent:
     def __init__(self, config_path: str | None = None) -> None:
         logger.debug("Initializing ClassifierAgent with config_path=%s", config_path)
         self.config = load_config(config_path)
-        llm = self.config.base_llm.lower()
-        logger.info("Loaded configuration for base LLM: %s", llm)
-        if llm == "openai":
-            logger.debug("Using OpenAIClient")
-            self.client = OpenAIClient(config_path)
-        elif llm in {"anthropic", "claude"}:
-            logger.debug("Using ClaudeClient")
-            self.client = ClaudeClient(config_path)
-        else:
-            logger.error("Unsupported LLM provider: %s", self.config.base_llm)
-            raise ValueError(f"Unsupported LLM provider: {self.config.base_llm}")
+        self.client = create_llm_client(config_path)
 
         # Tools available to this agent
         self.tools = [get_issue_by_id_tool]

--- a/src/agents/issue_insights.py
+++ b/src/agents/issue_insights.py
@@ -8,8 +8,7 @@ from typing import Any, Dict
 from datetime import datetime
 
 from src.configs.config import load_config
-from src.llm_clients.openai_client import OpenAIClient
-from src.llm_clients.claude_client import ClaudeClient
+from src.llm_clients import create_llm_client
 from src.prompts import load_prompt
 from src.utils import safe_format
 from src.services.jira_service import (
@@ -29,16 +28,7 @@ class IssueInsightsAgent:
     def __init__(self, config_path: str | None = None) -> None:
         logger.debug("Initializing IssueInsightsAgent with config_path=%s", config_path)
         self.config = load_config(config_path)
-        llm = self.config.base_llm.lower()
-        if llm == "openai":
-            logger.debug("Using OpenAIClient")
-            self.client = OpenAIClient(config_path)
-        elif llm in {"anthropic", "claude"}:
-            logger.debug("Using ClaudeClient")
-            self.client = ClaudeClient(config_path)
-        else:
-            logger.error("Unsupported LLM provider: %s", self.config.base_llm)
-            raise ValueError(f"Unsupported LLM provider: {self.config.base_llm}")
+        self.client = create_llm_client(config_path)
 
         # Tools available to this agent
         self.tools = [get_issue_by_id_tool, get_issue_history_tool]

--- a/src/llm_clients/__init__.py
+++ b/src/llm_clients/__init__.py
@@ -2,11 +2,30 @@
 
 import logging
 
+from typing import Optional
+
 from .openai_client import OpenAIClient
 from .claude_client import ClaudeClient
+from .base_llm_client import BaseLLMClient
+from src.configs.config import load_config
 
 logger = logging.getLogger(__name__)
 logger.debug("llm_clients package initialized")
 
-__all__ = ["OpenAIClient", "ClaudeClient"]
+def create_llm_client(config_path: Optional[str] = None) -> BaseLLMClient:
+    """Return an LLM client based on the configured provider."""
+    config = load_config(config_path)
+    llm = config.base_llm.lower()
+    logger.info("Selected base LLM: %s", llm)
+    if llm == "openai":
+        logger.debug("Creating OpenAIClient")
+        return OpenAIClient(config_path)
+    if llm in {"anthropic", "claude"}:
+        logger.debug("Creating ClaudeClient")
+        return ClaudeClient(config_path)
+    logger.error("Unsupported LLM provider: %s", config.base_llm)
+    raise ValueError(f"Unsupported LLM provider: {config.base_llm}")
+
+
+__all__ = ["OpenAIClient", "ClaudeClient", "create_llm_client"]
 


### PR DESCRIPTION
## Summary
- provide factory `create_llm_client` for selecting the LLM backend
- use this factory in `ClassifierAgent`, `IssueInsightsAgent` and `ApiValidatorAgent`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6847104fe0ac83289d4fd41de61f9da0