### PR TITLE
Add LangChain-based moderation safeguards

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains a Jira AI assistant that communicates with the OpenAI A
 - Simple utilities for retrieving Jira issue details
 - OpenAI service integration for AI-powered assistance
 - A minimal agent that combines both capabilities
+- Built-in LangChain moderation to reject unsafe or non-Jira questions
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- rely on LangChain's built-in moderation instead of custom regex
- reject unsafe or injected prompts via `OpenAIModerationChain`
- update README with LangChain moderation note

## Testing
- `python -m py_compile src/agents/router_agent.py`
- `python -m compileall -q src`


------
https://chatgpt.com/codex/tasks/task_b_68470fa687cc8328b5191b3bd5382f15