### PR TITLE
Add SimpleHttpClient utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,11 @@ The assistant now catches common issues such as invalid Jira keys or failures
 communicating with OpenAI. Instead of a stack trace you will receive a polite
 message explaining what went wrong so you can try again later.
 
+### Simple HTTP Client
+
+The ``SimpleHttpClient`` utility provides a minimal wrapper around
+``requests`` for quickly exercising external APIs.  It supports basic
+``get``, ``post``, ``put`` and ``delete`` helpers and can be initialized
+with an optional ``base_url``.  This makes it easy to experiment with new
+endpoints directly from Python without pulling in a larger framework.
+

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -4,6 +4,7 @@ from .jira import extract_plain_text, JiraUtils, strip_nulls, strip_unused_jira_
 from .prompt import safe_format
 from .rich_logger import RichLogger
 from .context_memory import JiraContextMemory
+from .http_client import SimpleHttpClient
 
 __all__ = [
     "extract_plain_text",
@@ -13,4 +14,5 @@ __all__ = [
     "safe_format",
     "RichLogger",
     "JiraContextMemory",
+    "SimpleHttpClient",
 ]

--- a/src/utils/http_client.py
+++ b/src/utils/http_client.py
@@ -1,0 +1,46 @@
+"""Minimal HTTP client for testing API endpoints."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+import logging
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class SimpleHttpClient:
+    """Thin wrapper around :mod:`requests` for basic API calls."""
+
+    def __init__(self, base_url: str | None = None) -> None:
+        self.base_url = base_url.rstrip("/") if base_url else ""
+        self.session = requests.Session()
+        logger.debug("SimpleHttpClient initialized with base_url=%s", self.base_url)
+
+    def _build_url(self, path: str) -> str:
+        if path.startswith("http://") or path.startswith("https://"):
+            return path
+        return f"{self.base_url}/{path.lstrip('/')}"
+
+    def request(self, method: str, path: str, **kwargs: Any) -> requests.Response:
+        """Send an HTTP request and return the :class:`Response`."""
+        url = self._build_url(path)
+        logger.debug("Performing %s request to %s with %s", method, url, kwargs)
+        response = self.session.request(method, url, **kwargs)
+        logger.info("%s %s -> %s", method, url, response.status_code)
+        return response
+
+    def get(self, path: str, params: Dict[str, Any] | None = None, **kwargs: Any) -> requests.Response:
+        return self.request("GET", path, params=params, **kwargs)
+
+    def post(self, path: str, data: Any | None = None, json: Any | None = None, **kwargs: Any) -> requests.Response:
+        return self.request("POST", path, data=data, json=json, **kwargs)
+
+    def put(self, path: str, data: Any | None = None, json: Any | None = None, **kwargs: Any) -> requests.Response:
+        return self.request("PUT", path, data=data, json=json, **kwargs)
+
+    def delete(self, path: str, **kwargs: Any) -> requests.Response:
+        return self.request("DELETE", path, **kwargs)
+
+
+__all__ = ["SimpleHttpClient"]


### PR DESCRIPTION
## Summary
- implement `SimpleHttpClient` in `src/utils`
- export new helper in package init
- document basic usage in README

## Testing
- `python -m py_compile src/utils/http_client.py`


------
https://chatgpt.com/codex/tasks/task_b_684716ce802c8328bd3236892fc4329a