### PR TITLE
Update backlog validation prompt

### DIFF
--- a/src/prompts/validation/validate_backlog.txt
+++ b/src/prompts/validation/validate_backlog.txt
@@ -1,38 +1,34 @@
-You are validating an issue currently marked as "Backlog".
-Required information we want to exist is :
-1. **Swagger URL**
-2. **HTTP Method**
-    - Exactly one of "POST", "GET", "PUT", or "DELETE" in uppercase.
-3. Some free text describing business logic of the api.Business logic should be meaningful not just some text. 
-  - Example: "Gets endpoint that provides a list of physical and legal entities who participate in some way in 
-    the system but are outside the main defined categories in people module 
-    (agents, clients, offices, employees, insurers, banks, experts, creditors and sales channels). 
-    The result contains details for their role according to the filter criteria provided in the query parameters."
-4. Parse the "Summary" and "Description." Ignore Jira-specific color tags or images unless they carry URLs or JSON blocks.
-{body_instructions}
-5. Return exactly one JSON object (no extra commentary) according to the schema below.
+You are validating a Jira issue to ensure it contains all required information before development can begin.
+Required for Development:
 
-**Output JSON Schema:**
-  ```json
-  {{
-  "jira_key": "string or null",
-  "is_valid": true | false,
-  "errors": ["list of missing, malformed, or inconsistent fields"],
-  "parsed": {{
+Swagger Specification URL - Link to API specification
+HTTP Method - One of: POST, GET, PUT, DELETE (uppercase)
+API Endpoint Path - The endpoint to implement
+Business Requirements - Clear description of what needs to be built (not just copy-paste text)
+
+Validation Rules:
+
+Check if ticket has enough detail for a developer to start work
+Business requirements must be specific to this feature
+All referenced URLs should be properly formatted
+Ignore Jira formatting unless it contains useful links or data
+
+Output Format:
+Return only a JSON object with this structure:
+json{
+  "jira_key": "string",
+  "is_valid": true/false,
+  "errors": ["array of specific issues"],
+  "parsed": {
     "swagger_url": "string or null",
-    "method": "POST" | "GET" | "PUT" | "DELETE" | null,
-    "api_url": "string or null",
-      "request_body_exists": true | false,
-      "request_body_valid": true | false,
-      "response_body_exists": true | false,
-      "response_body_valid": true | false,
-      "request_body_example": {{ ... }} | null,
-      "response_example": {{ ... }} | null,
-  }},
-  "jira_comment": "Natural-language summary of missing or malformed fields with specific example suggestions, appropriate to the development status. If the request body exists but is invalid, mention it."
-  }}
-  ```
+    "method": "POST|GET|PUT|DELETE or null",
+    "api_endpoint": "string or null",
+    "business_logic": "string or null"
+  },
+  "jira_comment": "Summary of what's missing or unclear for development, with specific suggestions"
+}
+Issue Details:
 
-Issue Key: {key}
+Key: {key}
 Summary: {summary}
 Description: {description}


### PR DESCRIPTION
## Summary
- simplify the backlog validation prompt to only require API spec, method, endpoint, and business logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6847fbd635cc8328aeb731a735d565a7