### PR TITLE
Add TestAgent for generating API test cases

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -13,6 +13,7 @@ from .api_validator import ApiValidatorAgent
 from .issue_insights import IssueInsightsAgent
 from .jira_operations import JiraOperationsAgent
 from .router_agent import RouterAgent
+from .test_agent import TestAgent
 
 __all__ = [
     "ClassifierAgent",
@@ -20,5 +21,6 @@ __all__ = [
     "IssueInsightsAgent",
     "JiraOperationsAgent",
     "RouterAgent",
+    "TestAgent",
 ]
 

--- a/src/agents/test_agent.py
+++ b/src/agents/test_agent.py
@@ -1,0 +1,47 @@
+"""Agent for generating test cases and exercising APIs."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from src.configs.config import load_config
+from src.llm_clients import create_llm_client
+from src.prompts import load_prompt
+from src.utils import safe_format
+
+logger = logging.getLogger(__name__)
+logger.debug("test_agent module loaded")
+
+
+class TestAgent:
+    """Agent that generates test cases from validation results."""
+
+    def __init__(self, config_path: str | None = None) -> None:
+        logger.debug("Initializing TestAgent with config_path=%s", config_path)
+        self.config = load_config(config_path)
+        self.client = create_llm_client(config_path)
+        self.prompt_template = load_prompt("tests/testCasesGeneration.txt")
+
+    def create_test_cases(self, validation_result: str, **kwargs: Any) -> str:
+        """Return test cases based on ``validation_result``."""
+        template = self.prompt_template or (
+            "Generate test cases based on the following validation summary:\n{summary}"
+        )
+        prompt = safe_format(template, {"summary": validation_result})
+        logger.info("Generating test cases from validation result")
+        messages = [{"role": "user", "content": prompt}]
+        response = self.client.chat_completion(messages, **kwargs)
+        try:
+            result = response.choices[0].message.content.strip()
+        except Exception:
+            try:
+                result = response["choices"][0]["message"]["content"].strip()
+            except Exception:  # pragma: no cover - handle unexpected structure
+                logger.exception("Failed to parse response")
+                result = str(response)
+        logger.debug("Generated test cases: %s", result)
+        return result
+
+
+__all__ = ["TestAgent"]

--- a/src/prompts/tests/testCasesGeneration.txt
+++ b/src/prompts/tests/testCasesGeneration.txt
@@ -1,0 +1,22 @@
+Generate three basic test cases for a GET API endpoint. Each test case should include:
+1. A concise **name**.
+2. A short **description** of what it verifies.
+3. **Steps** to perform the check.
+4. The **expected result**.
+
+Make them generic enough to apply to any GET endpoint before any implementation exists:
+- **Test Case 1: Success Path** — valid request returns 200 and correct payload.
+- **Test Case 2: Client Error** — malformed or missing parameters returns 400 with an error message.
+- **Test Case 3: Other Error** — non-existent resource or server fault returns an appropriate error code (e.g. 404 or 500).
+
+Output your answer as a JSON array of objects, for example:
+```
+[
+  {
+    "name": "Success - Retrieve Resource",
+    "description": "Valid GET request returns the resource.",
+    "steps": ["Call GET /your/endpoint with a known ID", "Inspect HTTP status and body"],
+    "expected": {"status": 200, "body": {"id": "<same ID>", "...": "..."}}
+  }
+]
+```


### PR DESCRIPTION
## Summary
- add a new `TestAgent` for producing test cases from validation output
- expose `TestAgent` from the agents package
- add prompt for test case generation

## Testing
- `python -m py_compile src/agents/test_agent.py`
- `python -m py_compile src/agents/__init__.py`
- `python - <<'PY'
from src.agents.test_agent import TestAgent
print('loaded')
PY
` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_68480b712f988328adb293f562511b40