### PR TITLE
Fix JSON parsing with code fences

### DIFF
--- a/src/agents/api_validator.py
+++ b/src/agents/api_validator.py
@@ -78,7 +78,17 @@ class ApiValidatorAgent:
             logger.exception("Failed to format prompt")
             return ""
         logger.debug("Prompt for validation: %s", prompt)
-        messages = [{"role": "user", "content": prompt}]
+        messages = []
+        if "Issue Details:" in prompt:
+            system_prompt, issue_prompt = prompt.split("Issue Details:", 1)
+            messages.append({"role": "system", "content": system_prompt.strip()})
+            messages.append({"role": "user", "content": "Issue Details:" + issue_prompt.strip()})
+        elif "Issue Key:" in prompt:
+            system_prompt, issue_prompt = prompt.split("Issue Key:", 1)
+            messages.append({"role": "system", "content": system_prompt.strip()})
+            messages.append({"role": "user", "content": "Issue Key:" + issue_prompt.strip()})
+        else:
+            messages.append({"role": "system", "content": prompt})
         response = self.client.chat_completion(messages, **kwargs)
         try:
             result = response.choices[0].message.content.strip()

--- a/src/agents/router_agent.py
+++ b/src/agents/router_agent.py
@@ -27,7 +27,7 @@ from src.agents.api_validator import ApiValidatorAgent
 from src.agents.jira_operations import JiraOperationsAgent
 from src.prompts import load_prompt
 from src.services.jira_service import get_issue_by_id_tool
-from src.utils import safe_format, JiraContextMemory
+from src.utils import safe_format, JiraContextMemory, parse_json_block
 
 from jira import JIRAError
 from openai import OpenAIError
@@ -155,10 +155,13 @@ class RouterAgent:
         """
         try:
             data = json.loads(result)
-            comment = data.get("jira_comment")
         except Exception:
+            data = parse_json_block(result)
+        if data is None:
             logger.debug("Validation result not JSON")
             comment = None
+        else:
+            comment = data.get("jira_comment") if isinstance(data, dict) else None
         if comment:
             if not self.config.write_comments_to_jira:
                 logger.info(

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -5,6 +5,7 @@ from .prompt import safe_format
 from .rich_logger import RichLogger
 from .context_memory import JiraContextMemory
 from .http_client import SimpleHttpClient
+from .json_utils import parse_json_block
 
 __all__ = [
     "extract_plain_text",
@@ -15,4 +16,5 @@ __all__ = [
     "RichLogger",
     "JiraContextMemory",
     "SimpleHttpClient",
+    "parse_json_block",
 ]

--- a/src/utils/json_utils.py
+++ b/src/utils/json_utils.py
@@ -1,0 +1,29 @@
+import json
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def parse_json_block(text: str) -> Optional[Any]:
+    """Return parsed JSON from ``text`` which may include markdown fences."""
+    if not isinstance(text, str):
+        return None
+    cleaned = text.strip()
+    if cleaned.startswith("```") and cleaned.endswith("```"):
+        cleaned = cleaned.strip("`")
+        if cleaned.lower().startswith("json"):
+            cleaned = cleaned[4:].strip()
+    try:
+        return json.loads(cleaned)
+    except Exception:
+        pass
+    start = cleaned.find('{')
+    end = cleaned.rfind('}')
+    if start != -1 and end != -1 and end > start:
+        candidate = cleaned[start:end + 1]
+        try:
+            return json.loads(candidate)
+        except Exception:
+            logger.debug("Failed to parse JSON block", exc_info=True)
+    return None


### PR DESCRIPTION
## Summary
- add `parse_json_block` utility
- handle JSON code fences in router validation results
- send validation prompts as a system message

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_68480d800ab88328b32e0ef119fc9937