### PR TITLE
Add confirmation prompt before posting Jira comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ LANGCHAIN_DEBUG=false
 RICH_LOGGING=true
 STRIP_UNUSED_JIRA_DATA=true
 FOLLOW_RELATED_JIRAS=false
+ASK_FOR_CONFIRMATION=false
 ```
 
 The default model and provider can be changed in `src/configs/config.yml` or by setting `OPENAI_MODEL` and `BASE_LLM` in the environment. The flag `INCLUDE_WHOLE_API_BODY` controls whether validation prompts should return the full API bodies or only boolean indicators of their validity.
@@ -33,6 +34,7 @@ The assistant also remembers the last Jira key you referenced. Follow-up questio
 
 Set `strip_unused_jira_data: true` in the config to remove avatar URLs and ID fields from Jira payloads for more concise outputs.
 Set `follow_related_jiras: true` to automatically fetch and summarize linked issues and subtasks when answering questions. Comments from those related tickets are also retrieved so important context isn't missed.
+Set `ask_for_confirmation: true` to require a confirmation prompt before posting comments back to Jira.
 
 ### Debug Logging
 

--- a/src/agents/router_agent.py
+++ b/src/agents/router_agent.py
@@ -169,6 +169,15 @@ class RouterAgent:
                     issue_id,
                 )
                 return False
+            if self.config.ask_for_confirmation:
+                ans = input(
+                    "Do you want me to add this comment to the jira ticket? [y/N]: "
+                ).strip().lower()
+                if not ans.startswith("y"):
+                    logger.info(
+                        "User declined to add comment to %s", issue_id
+                    )
+                    return False
             try:
                 self.operations.add_comment(issue_id, comment)
                 logger.info("Posted validation comment to %s", issue_id)

--- a/src/configs/config.py
+++ b/src/configs/config.py
@@ -34,6 +34,7 @@ class Config:
     strip_unused_jira_data: bool
     follow_related_jiras: bool
     write_comments_to_jira: bool
+    ask_for_confirmation: bool
     validation_prompts_dir: str = "validation"
 
 
@@ -112,5 +113,6 @@ def load_config(path: str = None) -> Config:
         strip_unused_jira_data=_env_bool("STRIP_UNUSED_JIRA_DATA", data.get("strip_unused_jira_data", False)),
         follow_related_jiras=_env_bool("FOLLOW_RELATED_JIRAS", data.get("follow_related_jiras", False)),
         write_comments_to_jira=_env_bool("WRITE_COMMENTS_TO_JIRA", data.get("write_comments_to_jira", False)),
+        ask_for_confirmation=_env_bool("ASK_FOR_CONFIRMATION", data.get("ask_for_confirmation", False)),
         validation_prompts_dir=os.getenv("VALIDATION_PROMPTS_DIR", data.get("validation_prompts_dir", "validation")),
     )

--- a/src/configs/config.yml
+++ b/src/configs/config.yml
@@ -17,3 +17,4 @@ strip_unused_jira_data: true
 follow_related_jiras: true
 validation_prompts_dir: validation
 write_comments_to_jira: false
+ask_for_confirmation: false


### PR DESCRIPTION
## Summary
- add `ask_for_confirmation` config option
- confirm with user before writing a comment to Jira
- document the new setting in README and default config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_68481184fdac832889147627b781e937