### PR TITLE
Fix add_comment tool invocation

### DIFF
--- a/src/agents/jira_operations.py
+++ b/src/agents/jira_operations.py
@@ -28,7 +28,8 @@ class JiraOperationsAgent:
     def add_comment(self, issue_id: str, comment: str, **kwargs: Any) -> str:
         """Add ``comment`` to ``issue_id`` using the Jira API."""
         logger.info("Adding comment to %s", issue_id)
-        result_json = add_comment_to_issue_tool.run(issue_id, comment)
+        payload = json.dumps({"issue_id": issue_id, "comment": comment})
+        result_json = add_comment_to_issue_tool.run(payload)
         try:
             parsed = json.loads(result_json)
         except Exception:


### PR DESCRIPTION
## Summary
- fix the JiraOperationsAgent so add_comment_to_issue gets JSON payload

## Testing
- `python -m pytest -q` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_6848144844648328ae5a17d32123b712