### PR TITLE
Fix OpenAI service path

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ What is the status of SD-99?
 The `OpenAIService` class can be used to ask arbitrary questions via the OpenAI chat API:
 
 ```bash
-python openai_service.py "What is 2 + 2?"
+python src/services/openai_service.py "What is 2 + 2?"
 ```
 
 ### AI Agent with Jira Tools


### PR DESCRIPTION
## Summary
- correct README example path for OpenAI service

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_684818d775748328a49598b0fc86ca52