### PR TITLE
Add test case generation based on HTTP method

### DIFF
--- a/src/prompts/tests/delete_test_cases.txt
+++ b/src/prompts/tests/delete_test_cases.txt
@@ -1,0 +1,22 @@
+Generate three basic test cases for a DELETE API endpoint. Each test case should include:
+1. A concise **name**.
+2. A short **description** of what it verifies.
+3. **Steps** to perform the check.
+4. The **expected result**.
+
+Make them generic enough for any DELETE endpoint before implementation exists:
+- **Test Case 1: Success Path** — valid request returns 204 or 200 with confirmation.
+- **Test Case 2: Not Found** — deleting a missing resource returns 404.
+- **Test Case 3: Other Error** — server fault returns an appropriate error code (e.g. 500).
+
+Output a JSON array of objects following this example:
+```
+[
+  {
+    "name": "Success - Delete Resource",
+    "description": "Valid DELETE removes the resource.",
+    "steps": ["DELETE /your/endpoint/1", "Check HTTP status"],
+    "expected": {"status": 204, "body": null}
+  }
+]
+```

--- a/src/prompts/tests/get_test_cases.txt
+++ b/src/prompts/tests/get_test_cases.txt
@@ -1,0 +1,22 @@
+Generate three basic test cases for a GET API endpoint. Each test case should include:
+1. A concise **name**.
+2. A short **description** of what it verifies.
+3. **Steps** to perform the check.
+4. The **expected result**.
+
+Make them generic enough to apply to any GET endpoint before any implementation exists:
+- **Test Case 1: Success Path** — valid request returns 200 and correct payload.
+- **Test Case 2: Client Error** — malformed or missing parameters returns 400 with an error message.
+- **Test Case 3: Other Error** — non-existent resource or server fault returns an appropriate error code (e.g. 404 or 500).
+
+Output your answer as a JSON array of objects, for example:
+```
+[
+  {
+    "name": "Success - Retrieve Resource",
+    "description": "Valid GET request returns the resource.",
+    "steps": ["Call GET /your/endpoint with a known ID", "Inspect HTTP status and body"],
+    "expected": {"status": 200, "body": {"id": "<same ID>", "...": "..."}}
+  }
+]
+```

--- a/src/prompts/tests/post_test_cases.txt
+++ b/src/prompts/tests/post_test_cases.txt
@@ -1,0 +1,22 @@
+Generate three basic test cases for a POST API endpoint. Each test case should include:
+1. A concise **name**.
+2. A short **description** of what it verifies.
+3. **Steps** to perform the check.
+4. The **expected result**.
+
+Make them generic enough for any POST endpoint before implementation exists:
+- **Test Case 1: Success Path** — valid body returns 201 with created resource.
+- **Test Case 2: Client Error** — missing or invalid fields returns 400 with an error message.
+- **Test Case 3: Other Error** — duplicate request or server fault returns an appropriate error code (e.g. 409 or 500).
+
+Output a JSON array of objects following this example:
+```
+[
+  {
+    "name": "Success - Create Resource",
+    "description": "Valid POST creates the resource.",
+    "steps": ["POST /your/endpoint with valid JSON", "Check HTTP status and response"],
+    "expected": {"status": 201, "body": {"id": "<generated>", "...": "..."}}
+  }
+]
+```

--- a/src/prompts/tests/put_test_cases.txt
+++ b/src/prompts/tests/put_test_cases.txt
@@ -1,0 +1,22 @@
+Generate three basic test cases for a PUT API endpoint. Each test case should include:
+1. A concise **name**.
+2. A short **description** of what it verifies.
+3. **Steps** to perform the check.
+4. The **expected result**.
+
+Make them generic enough for any PUT endpoint before implementation exists:
+- **Test Case 1: Success Path** — valid update returns 200 with updated resource.
+- **Test Case 2: Not Found** — updating a missing resource returns 404.
+- **Test Case 3: Other Error** — invalid body or server fault returns an appropriate error code (e.g. 400 or 500).
+
+Output a JSON array of objects following this example:
+```
+[
+  {
+    "name": "Success - Update Resource",
+    "description": "Valid PUT updates the resource.",
+    "steps": ["PUT /your/endpoint/1 with valid JSON", "Check HTTP status and response"],
+    "expected": {"status": 200, "body": {"id": 1, "...": "..."}}
+  }
+]
+```


### PR DESCRIPTION
## Summary
- enhance `TestAgent` to load prompts per HTTP method
- generate test cases after validation in `RouterAgent`
- add prompt templates for GET, POST, PUT and DELETE test cases

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_6848296c4b588328b01b6c7cdaf10598