### PR TITLE
Add TEST intent and routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains a Jira AI assistant that communicates with the OpenAI A
 - Simple utilities for retrieving Jira issue details
 - OpenAI service integration for AI-powered assistance
 - A minimal agent that combines both capabilities
+- Automated test case generation for API issues
 
 ## Configuration
 
@@ -91,6 +92,15 @@ uvicorn app:app --reload
 ```
 
 The `/ask` endpoint accepts a JSON payload containing a `question` field and returns the answer from the `RouterAgent`.
+
+### Test Case Generation
+
+Ask the assistant for test cases and it will validate the Jira issue and return
+basic scenarios.
+
+```bash
+python main.py "Generate test cases for RB-1234"
+```
 
 ### Error Handling
 

--- a/src/agents/router_agent.py
+++ b/src/agents/router_agent.py
@@ -242,6 +242,12 @@ class RouterAgent:
         if is_valid and method:
             return self.tester.create_test_cases(result, method, **kwargs)
         return None
+
+    def _validate_and_generate_tests(self, issue_id: str, **kwargs: Any) -> str:
+        """Run validation and return generated test cases if possible."""
+        validation = self._classify_and_validate(issue_id, **kwargs)
+        tests = self._generate_test_cases(validation, **kwargs)
+        return tests or validation
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -287,6 +293,9 @@ class RouterAgent:
                 tests = self._generate_test_cases(answer, **kwargs)
                 if tests:
                     answer += "\n\n" + tests
+            elif intent.startswith("TEST"):
+                logger.info("Routing to test generation workflow")
+                answer = self._validate_and_generate_tests(issue_id, **kwargs)
             elif intent.startswith("OPERATE"):
                 logger.info("Routing to operations workflow")
                 answer = "Operation handling not implemented"

--- a/src/prompts/intent_classifier.txt
+++ b/src/prompts/intent_classifier.txt
@@ -4,8 +4,9 @@ Possible intents:
 - VALIDATE: Validate the API of a Jira issue
 - OPERATE: Perform a Jira operation (add comment, close issue, assign, etc.)
 - INSIGHT: Answer a question about the Jira issue
+- TEST: Generate test cases for the API of a Jira issue
 - UNKNOWN: Not sure what the intent is
 
 Question: {question}
 
-Respond with one of: VALIDATE, OPERATE, INSIGHT, UNKNOWN
+Respond with one of: VALIDATE, OPERATE, INSIGHT, TEST, UNKNOWN


### PR DESCRIPTION
## Summary
- clarify ability to generate test cases in README
- update intent classifier with new TEST intent
- route TEST intent in `RouterAgent`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_68483ce8e5988328842b27c75d4b93e4