### PR TITLE
Enable test generation when validation fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ The `/ask` endpoint accepts a JSON payload containing a `question` field and ret
 
 ### Test Case Generation
 
-Ask the assistant for test cases and it will validate the Jira issue and return
-basic scenarios.
+Ask the assistant for test cases and it will validate the Jira issue before trying
+to generate them. If the ticket lacks enough details the assistant will reply
+"Not enough information to generate test cases." otherwise it returns basic scenarios.
 
 ```bash
 python main.py "Generate test cases for RB-1234"

--- a/src/agents/router_agent.py
+++ b/src/agents/router_agent.py
@@ -226,28 +226,30 @@ class RouterAgent:
                 )
         return False
 
-    def _generate_test_cases(self, result: str, **kwargs: Any) -> str | None:
-        """Return test cases string if validation ``result`` is sufficient."""
+    def _generate_test_cases(self, result: str, **kwargs: Any) -> str:
+        """Return test cases string generated from ``result``."""
         try:
             data = json.loads(result)
         except Exception:
             data = parse_json_block(result)
-        if not isinstance(data, dict):
-            return None
-        is_valid = data.get("is_valid")
+
         method = None
-        parsed = data.get("parsed")
-        if isinstance(parsed, dict):
-            method = parsed.get("method")
-        if is_valid and method:
+        if isinstance(data, dict):
+            parsed = data.get("parsed")
+            if isinstance(parsed, dict):
+                method = parsed.get("method")
+
+        try:
             return self.tester.create_test_cases(result, method, **kwargs)
-        return None
+        except Exception:
+            logger.exception("Failed to generate test cases")
+            return "Not enough information to generate test cases."
 
     def _validate_and_generate_tests(self, issue_id: str, **kwargs: Any) -> str:
         """Run validation and return generated test cases if possible."""
         validation = self._classify_and_validate(issue_id, **kwargs)
         tests = self._generate_test_cases(validation, **kwargs)
-        return tests or validation
+        return tests
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------

--- a/src/prompts/tests/delete_test_cases.txt
+++ b/src/prompts/tests/delete_test_cases.txt
@@ -9,6 +9,9 @@ Make them generic enough for any DELETE endpoint before implementation exists:
 - **Test Case 2: Not Found** — deleting a missing resource returns 404.
 - **Test Case 3: Other Error** — server fault returns an appropriate error code (e.g. 500).
 
+If the summary does not provide enough details to create meaningful tests, reply with:
+"Not enough information to generate test cases."
+
 Output a JSON array of objects following this example:
 ```
 [

--- a/src/prompts/tests/get_test_cases.txt
+++ b/src/prompts/tests/get_test_cases.txt
@@ -9,6 +9,9 @@ Make them generic enough to apply to any GET endpoint before any implementation 
 - **Test Case 2: Client Error** — malformed or missing parameters returns 400 with an error message.
 - **Test Case 3: Other Error** — non-existent resource or server fault returns an appropriate error code (e.g. 404 or 500).
 
+If the summary does not provide enough details to create meaningful tests, reply with:
+"Not enough information to generate test cases."
+
 Output your answer as a JSON array of objects, for example:
 ```
 [

--- a/src/prompts/tests/post_test_cases.txt
+++ b/src/prompts/tests/post_test_cases.txt
@@ -9,6 +9,9 @@ Make them generic enough for any POST endpoint before implementation exists:
 - **Test Case 2: Client Error** — missing or invalid fields returns 400 with an error message.
 - **Test Case 3: Other Error** — duplicate request or server fault returns an appropriate error code (e.g. 409 or 500).
 
+If the summary does not provide enough details to create meaningful tests, reply with:
+"Not enough information to generate test cases."
+
 Output a JSON array of objects following this example:
 ```
 [

--- a/src/prompts/tests/put_test_cases.txt
+++ b/src/prompts/tests/put_test_cases.txt
@@ -9,6 +9,9 @@ Make them generic enough for any PUT endpoint before implementation exists:
 - **Test Case 2: Not Found** — updating a missing resource returns 404.
 - **Test Case 3: Other Error** — invalid body or server fault returns an appropriate error code (e.g. 400 or 500).
 
+If the summary does not provide enough details to create meaningful tests, reply with:
+"Not enough information to generate test cases."
+
 Output a JSON array of objects following this example:
 ```
 [

--- a/src/prompts/tests/testCasesGeneration.txt
+++ b/src/prompts/tests/testCasesGeneration.txt
@@ -9,6 +9,9 @@ Make them generic enough to apply to any GET endpoint before any implementation 
 - **Test Case 2: Client Error** — malformed or missing parameters returns 400 with an error message.
 - **Test Case 3: Other Error** — non-existent resource or server fault returns an appropriate error code (e.g. 404 or 500).
 
+If the summary does not provide enough details to create meaningful tests, reply with:
+"Not enough information to generate test cases."
+
 Output your answer as a JSON array of objects, for example:
 ```
 [


### PR DESCRIPTION
## Summary
- allow RouterAgent to always attempt to generate tests
- tweak README docs on test case generation
- update test prompts to reply with "Not enough information" when details are missing

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_68483f3e7094832885520794b09a6534