### PR TITLE
Implement Jira operations workflow

### DIFF
--- a/src/agents/router_agent.py
+++ b/src/agents/router_agent.py
@@ -275,47 +275,48 @@ class RouterAgent:
             self.session_memory.current_issue = issue_id
         else:
             issue_id = self.session_memory.current_issue
-        if not issue_id:
-            answer = "No Jira ticket found in question"
-            if self.use_memory and self.memory is not None:
-                self.memory.chat_memory.add_ai_message(answer)
-            self.session_memory.save_context({"input": question}, {"output": answer})
-            return answer
 
         try:
             intent = self._classify_intent(question, **kwargs)
-            if intent.startswith("VALIDATE"):
-                logger.info("Routing to validation workflow")
-                answer = self._classify_and_validate(issue_id, **kwargs)
-                comment_posted = self._handle_validation_result(issue_id, answer)
-                if comment_posted:
-                    answer += "\n\nValidation summary posted as a Jira comment."
-                tests = self._generate_test_cases(answer, **kwargs)
-                if tests:
-                    answer += "\n\n" + tests
-            elif intent.startswith("TEST"):
-                logger.info("Routing to test generation workflow")
-                answer = self._validate_and_generate_tests(issue_id, **kwargs)
-            elif intent.startswith("OPERATE"):
+            if intent.startswith("OPERATE"):
                 logger.info("Routing to operations workflow")
-                answer = "Operation handling not implemented"
+                answer = self.operations.operate(question, issue_id=issue_id, **kwargs)
             else:
-                logger.info("Routing to general insights workflow")
-                include_history = self._needs_history(question, **kwargs)
-                history_msgs = None
-                if self.use_memory:
-                    role_map = {"human": "user", "ai": "assistant"}
-                    history_msgs = [
-                        {"role": role_map.get(m.type, m.type), "content": m.content}
-                        for m in self.memory.chat_memory.messages
-                    ]
-                answer = self.insights.ask(
-                    issue_id,
-                    question,
-                    include_history=include_history,
-                    history=history_msgs,
-                    **kwargs,
-                )
+                if not issue_id:
+                    answer = "No Jira ticket found in question"
+                    if self.use_memory and self.memory is not None:
+                        self.memory.chat_memory.add_ai_message(answer)
+                    self.session_memory.save_context({"input": question}, {"output": answer})
+                    return answer
+                if intent.startswith("VALIDATE"):
+                    logger.info("Routing to validation workflow")
+                    answer = self._classify_and_validate(issue_id, **kwargs)
+                    comment_posted = self._handle_validation_result(issue_id, answer)
+                    if comment_posted:
+                        answer += "\n\nValidation summary posted as a Jira comment."
+                    tests = self._generate_test_cases(answer, **kwargs)
+                    if tests:
+                        answer += "\n\n" + tests
+                elif intent.startswith("TEST"):
+                    logger.info("Routing to test generation workflow")
+                    answer = self._validate_and_generate_tests(issue_id, **kwargs)
+                else:
+                    logger.info("Routing to general insights workflow")
+                    include_history = self._needs_history(question, **kwargs)
+                    history_msgs = None
+                    if self.use_memory:
+                        role_map = {"human": "user", "ai": "assistant"}
+                        history_msgs = [
+                            {"role": role_map.get(m.type, m.type), "content": m.content}
+                            for m in self.memory.chat_memory.messages
+                        ]
+                    answer = self.insights.ask(
+                        issue_id,
+                        question,
+                        include_history=include_history,
+                        history=history_msgs,
+                        **kwargs,
+                    )
         except JIRAError:
             logger.exception("Jira error while fetching issue %s", issue_id)
             answer = f"Sorry, I couldn't find the Jira issue {issue_id}. Please check the key and try again."

--- a/src/prompts/jira_operations.txt
+++ b/src/prompts/jira_operations.txt
@@ -1,0 +1,10 @@
+You are a Jira assistant that converts user requests into structured actions.
+Supported actions:
+- add_comment: add a comment to an existing issue. Requires "issue_id" and "comment".
+- create_issue: create a new issue. Requires "project_key", "summary", "description" and optional "issue_type".
+- fill_field_by_label: set a field value using its display label. Requires "issue_id", "field_label", and "value".
+- update_fields: update one or more fields using a JSON mapping. Requires "issue_id" and "fields" (object).
+The current issue is {issue_id}. Use it if the request does not specify one.
+Respond with a single JSON object describing the action to perform.
+If you are unsure, respond with {"action": "unknown"}.
+Request: {question}


### PR DESCRIPTION
## Summary
- add prompt to plan Jira operations
- implement natural language operation handling in `JiraOperationsAgent`
- update router to dispatch OPERATE intent to the operations agent

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_b_68483d4c51708328b672a227224c8677