### PR TITLE
Improve utils classes

### DIFF
--- a/src/utils/context_memory.py
+++ b/src/utils/context_memory.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 """Lightweight memory for tracking the current Jira issue in a conversation."""
 
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, Optional, Deque
+from collections import deque
 import re
 
 try:
@@ -14,9 +15,10 @@ except Exception:  # pragma: no cover - langchain optional
 class JiraContextMemory(BaseMemory):
     """Simple conversation memory keeping track of a Jira issue id."""
 
-    def __init__(self) -> None:
+    def __init__(self, max_turns: int = 10) -> None:
+        self.max_turns = max_turns
         self.current_issue: Optional[str] = None
-        self.chat_history: List[str] = []
+        self.chat_history: Deque[str] = deque(maxlen=2 * max_turns)
 
     # ------------------------------------------------------------------
     # BaseMemory API
@@ -50,7 +52,7 @@ class JiraContextMemory(BaseMemory):
     def clear(self) -> None:
         """Reset memory state."""
         self.current_issue = None
-        self.chat_history = []
+        self.chat_history = deque(maxlen=2 * self.max_turns)
 
     # ------------------------------------------------------------------
     # Helpers

--- a/src/utils/http_client.py
+++ b/src/utils/http_client.py
@@ -17,6 +17,19 @@ class SimpleHttpClient:
         self.session = requests.Session()
         logger.debug("SimpleHttpClient initialized with base_url=%s", self.base_url)
 
+    # ------------------------------------------------------------------
+    # Context manager
+    # ------------------------------------------------------------------
+    def __enter__(self) -> "SimpleHttpClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Close the underlying :class:`requests.Session`."""
+        self.session.close()
+
     def _build_url(self, path: str) -> str:
         if path.startswith("http://") or path.startswith("https://"):
             return path

--- a/src/utils/rich_logger.py
+++ b/src/utils/rich_logger.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 try:
     from langchain.callbacks.base import BaseCallbackHandler
@@ -12,30 +12,31 @@ try:
 except Exception:  # pragma: no cover - rich not installed
     Console = None  # type: ignore
 
-console = Console() if Console else None
-
 
 class RichLogger(BaseCallbackHandler):
     """Simple LangChain callback for colorful logs."""
 
+    def __init__(self, console: Optional[Console] = None) -> None:
+        self.console = console or (Console() if Console else None)
+
     def on_tool_start(self, serialized: Any, input_str: str | dict, **kwargs: Any) -> None:  # type: ignore[override]
-        if not console:
+        if not self.console:
             return
-        console.rule(f"[bold blue]Tool: {serialized}")
-        console.print(f"[cyan]Input:[/] {input_str}")
+        self.console.rule(f"[bold blue]Tool: {serialized}")
+        self.console.print(f"[cyan]Input:[/] {input_str}")
 
     def on_tool_end(self, output: Any, **kwargs: Any) -> None:  # type: ignore[override]
-        if not console:
+        if not self.console:
             return
-        console.print(f"[green]Output:[/] {output}")
+        self.console.print(f"[green]Output:[/] {output}")
 
     def on_llm_start(self, serialized: Any, prompts: list[str], **kwargs: Any) -> None:  # type: ignore[override]
-        if not console:
+        if not self.console:
             return
         for prompt in prompts:
-            console.print(f"[blue][LLM Prompt][/]: {prompt}")
+            self.console.print(f"[blue][LLM Prompt][/]: {prompt}")
 
     def on_llm_end(self, response: Any, **kwargs: Any) -> None:  # type: ignore[override]
-        if not console:
+        if not self.console:
             return
-        console.print(f"[magenta][LLM Response][/]: {response}")
+        self.console.print(f"[magenta][LLM Response][/]: {response}")


### PR DESCRIPTION
## Summary
- track conversation history using a bounded deque in `JiraContextMemory`
- add context manager support to `SimpleHttpClient`
- make `RichLogger` configurable via its constructor

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_684849d33a348328b03b214b666ccf97