### PR TITLE
Enhance prompts, revert extras

### DIFF
--- a/src/agents/api_validator.py
+++ b/src/agents/api_validator.py
@@ -55,12 +55,10 @@ class ApiValidatorAgent:
 
         template = self.prompts.get(status)
         if not template:
-            logger.warning("No prompt found for status %s", status)
-            template = self.general_prompt
-            if not template:
-                return ""
-        elif self.general_prompt:
-            template = f"{self.general_prompt}\n{template}"
+            raise RuntimeError(f"No validation prompt for status {status}")
+        if not self.general_prompt:
+            raise RuntimeError("General validation prompt not found")
+        template = f"{self.general_prompt}\n{template}"
 
         values = {
             "key": issue.get("key", ""),

--- a/src/agents/jira_operations.py
+++ b/src/agents/jira_operations.py
@@ -96,11 +96,9 @@ class JiraOperationsAgent:
     # ------------------------------------------------------------------
     def _plan_operation(self, question: str, issue_id: str | None = None, **kwargs: Any) -> dict[str, Any]:
         """Return an action plan dict for ``question`` using the LLM."""
-        template = self.plan_prompt or (
-            "Convert the user request into a JSON action. Current issue: {issue_id}.\n"
-            "Supported actions: add_comment, create_issue, fill_field_by_label, update_fields.\n"
-            "Request: {question}"
-        )
+        if not self.plan_prompt:
+            raise RuntimeError("Jira operations prompt not found")
+        template = self.plan_prompt
         prompt = safe_format(template, {"question": question, "issue_id": issue_id or ""})
         messages = [{"role": "user", "content": prompt}]
         response = self.client.chat_completion(messages, **kwargs)

--- a/src/agents/router_agent.py
+++ b/src/agents/router_agent.py
@@ -134,17 +134,9 @@ class RouterAgent:
 
     def _classify_intent(self, question: str, **kwargs: Any) -> str:
         """Return the intent label for ``question`` using the classifier agent."""
-        if self.intent_prompt:
-            prompt = safe_format(self.intent_prompt, {"question": question})
-        else:
-            prompt = (
-                "You are a Jira assistant. Classify the user intent based on the question below.\n"
-                "Possible intents:\n- VALIDATE: Validate the API of a Jira issue\n"
-                "- OPERATE: Perform a Jira operation (add comment, close issue, assign, etc.)\n"
-                "- INSIGHT: Answer a question about the Jira issue\n"
-                "- UNKNOWN: Not sure what the intent is\n\nQuestion: {question}\n"
-                "Respond with one of: VALIDATE, OPERATE, INSIGHT, UNKNOWN"
-            ).format(question=question)
+        if not self.intent_prompt:
+            raise RuntimeError("Intent classification prompt not found")
+        prompt = safe_format(self.intent_prompt, {"question": question})
         label = self.classifier.classify(prompt, **kwargs)
         result = str(label).strip().upper()
         logger.debug("Intent classification result: %s", result)
@@ -156,13 +148,9 @@ class RouterAgent:
 
     def _needs_history(self, question: str, **kwargs: Any) -> bool:
         """Return True if the LLM determines the changelog is required."""
-        if self.history_prompt:
-            prompt = safe_format(self.history_prompt, {"question": question})
-        else:
-            prompt = (
-                "Do we need the change history to answer this question? "
-                "Respond with HISTORY or NO_HISTORY.\nQuestion: " + question
-            )
+        if not self.history_prompt:
+            raise RuntimeError("History check prompt not found")
+        prompt = safe_format(self.history_prompt, {"question": question})
         label = self.classifier.classify(prompt, **kwargs)
         result = str(label).strip().upper().startswith("HISTORY")
         logger.debug("Needs history: %s (label=%s)", result, label)

--- a/src/agents/test_agent.py
+++ b/src/agents/test_agent.py
@@ -73,9 +73,9 @@ class TestAgent:
     ) -> str:
         """Return test cases based on ``validation_result`` and HTTP ``method``."""
         method = (method or self._extract_method(validation_result) or "GET").upper()
-        template = self.prompts.get(method) or self.default_prompt or (
-            "Generate test cases based on the following validation summary:\n{summary}"
-        )
+        template = self.prompts.get(method) or self.default_prompt
+        if not template:
+            raise RuntimeError("Test case generation prompt not found")
         prompt = safe_format(template, {"summary": validation_result})
         logger.info("Generating test cases from validation result")
         messages = [{"role": "user", "content": prompt}]

--- a/src/utils/json_utils.py
+++ b/src/utils/json_utils.py
@@ -9,6 +9,7 @@ def parse_json_block(text: str) -> Optional[Any]:
     """Return parsed JSON from ``text`` which may include markdown fences."""
     if not isinstance(text, str):
         return None
+
     cleaned = text.strip()
     if cleaned.startswith("```") and cleaned.endswith("```"):
         cleaned = cleaned.strip("`")


### PR DESCRIPTION
## Summary
- keep stricter prompt requirements
- drop experimental ConversationFlow helper
- revert thread-locking in JiraContextMemory
- restore simpler JSON parsing logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6848473170a483288d7dfe79a8c75d50