### PR TITLE
Add confirmation prompts for Jira changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The assistant also remembers the last Jira key you referenced. Follow-up questio
 
 Set `strip_unused_jira_data: true` in the config to remove avatar URLs and ID fields from Jira payloads for more concise outputs.
 Set `follow_related_jiras: true` to automatically fetch and summarize linked issues and subtasks when answering questions. Comments from those related tickets are also retrieved so important context isn't missed.
-Set `ask_for_confirmation: true` to require a confirmation prompt before posting comments back to Jira.
+Set `ask_for_confirmation: true` to require a confirmation prompt before any changes are made in Jira, including creating issues, updating fields and posting comments.
 
 ### Debug Logging
 

--- a/src/agents/router_agent.py
+++ b/src/agents/router_agent.py
@@ -196,10 +196,11 @@ class RouterAgent:
                 )
                 return False
             if self.config.ask_for_confirmation:
-                ans = input(
-                    "Do you want me to add this comment to the jira ticket? [y/N]: "
-                ).strip().lower()
-                if not ans.startswith("y"):
+                from src.utils import confirm_action
+
+                if not confirm_action(
+                    f"Should I post the suggested comment to {issue_id}?"
+                ):
                     logger.info(
                         "User declined to add comment to %s", issue_id
                     )

--- a/src/services/jira_service.py
+++ b/src/services/jira_service.py
@@ -56,6 +56,13 @@ def create_jira_issue_func(
     logger.debug(
         "Creating Jira issue in project %s with summary %s", project_key, summary
     )
+    from src.utils import confirm_action
+
+    if not confirm_action(
+        f"Create issue in {project_key} with summary '{summary}'?"
+    ):
+        logger.info("User declined to create issue in %s", project_key)
+        return "Creation cancelled by user"
     client = _get_jira_client()
     fields: Dict[str, Any] = {
         "project": {"key": project_key},
@@ -150,6 +157,11 @@ get_related_issues_tool = Tool(
 def add_comment_to_issue_func(issue_id: str, comment: str) -> str:
     """Add a comment to the specified issue."""
     logger.debug("Adding comment to issue %s", issue_id)
+    from src.utils import confirm_action
+
+    if not confirm_action(f"Add the proposed comment to {issue_id}?"):
+        logger.info("User declined to add comment to %s", issue_id)
+        return "Comment creation cancelled by user"
     client = _get_jira_client()
     result = client.add_comment(issue_id, comment)
     logger.info("Added comment to issue %s", issue_id)
@@ -195,6 +207,11 @@ def update_issue_fields_func(issue_id: str, fields_json: str) -> str:
     ``fields_json`` should be a JSON string mapping field names to new values.
     """
     logger.debug("Updating issue %s with fields %s", issue_id, fields_json)
+    from src.utils import confirm_action
+
+    if not confirm_action(f"Apply the provided updates to {issue_id}?"):
+        logger.info("User declined to update %s", issue_id)
+        return "Update cancelled by user"
     client = _get_jira_client()
     fields: Dict[str, Any] = json.loads(fields_json)
     updated = client.update_issue(issue_id, fields)
@@ -207,6 +224,13 @@ def fill_field_by_label_func(issue_id: str, field_label: str, value: str) -> str
     logger.debug(
         "Filling field %s on %s with value %s", field_label, issue_id, value
     )
+    from src.utils import confirm_action
+
+    if not confirm_action(
+        f"Set '{field_label}' on {issue_id} to '{value}'?"
+    ):
+        logger.info("User declined to update %s", issue_id)
+        return "Field update cancelled by user"
     client = _get_jira_client()
     updated = client.set_field_by_label(issue_id, field_label, value)
     logger.info("Updated %s on %s", field_label, issue_id)

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -6,6 +6,17 @@ from .rich_logger import RichLogger
 from .context_memory import JiraContextMemory
 from .http_client import SimpleHttpClient
 from .json_utils import parse_json_block
+from src.configs.config import load_config
+
+
+def confirm_action(message: str) -> bool:
+    """Return ``True`` if the user confirms the suggested Jira action."""
+
+    cfg = load_config()
+    if not cfg.ask_for_confirmation:
+        return True
+    ans = input(f"{message} [y/N]: ").strip().lower()
+    return ans.startswith("y")
 
 __all__ = [
     "extract_plain_text",
@@ -17,4 +28,5 @@ __all__ = [
     "JiraContextMemory",
     "SimpleHttpClient",
     "parse_json_block",
+    "confirm_action",
 ]


### PR DESCRIPTION
## Summary
- add `confirm_action` utility to centralize prompts
- ask before posting validation comments
- require confirmation for issue creation, updates and comments
- document new confirmation behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_6848514c91f4832884047d48eac35856