### PR TITLE
Update acceptance criteria with generated tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ Ask the assistant for test cases and it will validate the Jira issue before tryi
 to generate them. If the ticket lacks enough details the assistant will reply
 "Not enough information to generate test cases." otherwise it returns basic scenarios.
 
+When tests are successfully generated they are also written to the issue's
+**Acceptance Criteria** field using the Jira API.
+
 ```bash
 python main.py "Generate test cases for RB-1234"
 ```


### PR DESCRIPTION
## Summary
- write generated tests to the Jira 'Acceptance Criteria' field
- document new behaviour in the README

## Testing
- `python -m py_compile src/agents/router_agent.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_6848559be5fc8328b1e5a4ceeedabfe2