### PR TITLE
Add tests to Jira issue description

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Ask the assistant for test cases and it will validate the Jira issue before tryi
 to generate them. If the ticket lacks enough details the assistant will reply
 "Not enough information to generate test cases." otherwise it returns basic scenarios.
 
-When tests are successfully generated they are also written to the issue's
-**Acceptance Criteria** field using the Jira API.
+When tests are successfully generated they are appended to the end of the issue's
+**Description** field using the Jira API.
 
 ```bash
 python main.py "Generate test cases for RB-1234"


### PR DESCRIPTION
## Summary
- append generated tests to the Description field instead of Acceptance Criteria
- note the new behaviour in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_684867bb4a188328abc40ec9f0e14fe0