### PR TITLE
Fix fill_field_by_label tool argument handling

### DIFF
--- a/src/services/jira_service.py
+++ b/src/services/jira_service.py
@@ -247,9 +247,37 @@ def fill_field_by_label_func(issue_id: str, field_label: str, value: str) -> str
     return json.dumps(updated)
 
 
+def _fill_field_by_label_wrapper(*args: str) -> str:
+    """Wrapper allowing single or triple argument invocation."""
+    if len(args) == 1:
+        text = args[0]
+        try:
+            data = json.loads(text)
+            issue_id = data["issue_id"]
+            field_label = data["field_label"]
+            value = data["value"]
+        except Exception:
+            if "|" in text:
+                issue_id, field_label, value = text.split("|", 2)
+            else:
+                raise TypeError(
+                    "fill_field_by_label requires 'issue_id|field_label|value' or JSON"
+                )
+    elif len(args) == 3:
+        issue_id, field_label, value = args
+    else:
+        raise TypeError(
+            "fill_field_by_label expects issue_id, field_label and value"
+        )
+
+    return fill_field_by_label_func(
+        issue_id.strip(), field_label.strip(), value.strip()
+    )
+
+
 fill_field_by_label_tool = Tool(
     name="fill_field_by_label",
-    func=fill_field_by_label_func,
+    func=_fill_field_by_label_wrapper,
     description=(
         "Set a field's value using the human readable label. Provide the issue key,"
         " the field label such as 'Definition Of Done' and the new value."


### PR DESCRIPTION
## Summary
- add `_fill_field_by_label_wrapper` to accept json string or separate args
- update `fill_field_by_label_tool` to use the wrapper

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68492c999dc8832885fd301e5ab7899f