### PR TITLE
Add planning pipeline for test agent

### DIFF
--- a/src/agents/planning.py
+++ b/src/agents/planning.py
@@ -1,0 +1,40 @@
+"""Utilities for creating multi-step planning chains."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+try:
+    from langchain.chains import LLMChain, SequentialChain  # type: ignore
+    from langchain.prompts import PromptTemplate  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    LLMChain = None  # type: ignore
+    SequentialChain = None  # type: ignore
+    PromptTemplate = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+logger.debug("planning module loaded")
+
+
+def create_planning_pipeline(
+    llm: Any,
+    method_prompt: PromptTemplate,
+    context_prompt: PromptTemplate,
+    test_prompt: PromptTemplate,
+) -> Any:
+    """Return a SequentialChain for method detection, context analysis and test generation."""
+    if None in (LLMChain, SequentialChain):
+        logger.warning("LangChain not installed; cannot create planning pipeline")
+        return None
+    method_chain = LLMChain(llm=llm, prompt=method_prompt, output_key="method")
+    context_chain = LLMChain(llm=llm, prompt=context_prompt, output_key="summary")
+    test_chain = LLMChain(llm=llm, prompt=test_prompt, output_key="test_cases")
+    return SequentialChain(
+        chains=[method_chain, context_chain, test_chain],
+        input_variables=["question", "jira_content"],
+        output_variables=["test_cases"],
+    )
+
+
+__all__ = ["create_planning_pipeline"]

--- a/src/llm_clients/__init__.py
+++ b/src/llm_clients/__init__.py
@@ -7,6 +7,7 @@ from typing import Optional
 from .openai_client import OpenAIClient
 from .claude_client import ClaudeClient
 from .base_llm_client import BaseLLMClient
+from .langchain_factory import create_langchain_llm
 from src.configs.config import load_config
 
 logger = logging.getLogger(__name__)
@@ -27,5 +28,10 @@ def create_llm_client(config_path: Optional[str] = None) -> BaseLLMClient:
     raise ValueError(f"Unsupported LLM provider: {config.base_llm}")
 
 
-__all__ = ["OpenAIClient", "ClaudeClient", "create_llm_client"]
+__all__ = [
+    "OpenAIClient",
+    "ClaudeClient",
+    "create_llm_client",
+    "create_langchain_llm",
+]
 

--- a/src/llm_clients/langchain_factory.py
+++ b/src/llm_clients/langchain_factory.py
@@ -1,0 +1,36 @@
+"""Factory for LangChain LLMs based on configuration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from src.configs.config import load_config
+
+logger = logging.getLogger(__name__)
+
+
+def create_langchain_llm(config_path: Optional[str] = None) -> Any:
+    """Return a LangChain compatible LLM based on ``base_llm`` setting."""
+    config = load_config(config_path)
+    provider = config.base_llm.lower()
+    try:
+        if provider == "openai":
+            from langchain_openai import ChatOpenAI  # type: ignore
+
+            return ChatOpenAI(model=config.openai_model, api_key=config.openai_api_key)
+        if provider in {"anthropic", "claude"}:
+            try:
+                from langchain_anthropic import ChatAnthropic  # type: ignore
+            except Exception:  # pragma: no cover - optional dependency
+                logger.warning("langchain-anthropic not installed")
+                return None
+            return ChatAnthropic(model=config.anthropic_model, api_key=config.anthropic_api_key)
+    except Exception:  # pragma: no cover - graceful degradation
+        logger.exception("Failed to initialize LangChain LLM")
+        return None
+    logger.error("Unsupported base LLM: %s", provider)
+    return None
+
+
+__all__ = ["create_langchain_llm"]

--- a/src/prompts/tests/context_analysis.txt
+++ b/src/prompts/tests/context_analysis.txt
@@ -1,0 +1,3 @@
+Analyze the Jira content for the {method} endpoint and outline the key scenarios that should be tested.
+Jira Content:
+{jira_content}

--- a/src/prompts/tests/method_detection.txt
+++ b/src/prompts/tests/method_detection.txt
@@ -1,0 +1,1 @@
+Return only the HTTP method mentioned in the question (GET, POST, PUT or DELETE). If none is found, return GET.


### PR DESCRIPTION
## Summary
- implement reusable planning pipeline utility
- add prompts for method detection and context analysis
- extend `TestAgent` with planning functionality using `SequentialChain`
- remove OpenAI-specific setup and create LLM-agnostic factory for planning

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_6849389e7d4c83289cdacf549367b110