### PR TITLE
fix prompt for POST test cases

### DIFF
--- a/src/prompts/tests/post_test_cases.txt
+++ b/src/prompts/tests/post_test_cases.txt
@@ -11,7 +11,7 @@ Make them generic enough for any POST endpoint before implementation exists:
 If the summary does not provide enough details to create meaningful tests, reply with:
 "Not enough information to generate test cases."
 
-Output a JSON array of objects following this example:
+Output your answer as Markdown following this example:
 ```markdown
 ### Test Case 1: Success - Create Resource
 


### PR DESCRIPTION
## Summary
- clarify instructions in `post_test_cases.txt` to request Markdown output

## Testing
- `pytest -q` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_684955a7617c8328a36c96cb58df0a54