### PR TITLE
Limit httpcore debug logging

### DIFF
--- a/src/configs/config.py
+++ b/src/configs/config.py
@@ -55,6 +55,9 @@ def setup_logging(config: "Config") -> None:
             format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         )
     logger.debug("Logging initialized at level %s", logging.getLevelName(level))
+    # Suppress noisy debug output from third-party HTTP clients
+    logging.getLogger("httpcore").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
     try:
         import langchain
 


### PR DESCRIPTION
## Summary
- quiet debug output from `httpcore` and `httpx`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_68496cb3d1bc83289b8d5da094a38efc