### PR TITLE
Update router agent test case docstring

### DIFF
--- a/src/agents/router_agent.py
+++ b/src/agents/router_agent.py
@@ -229,7 +229,10 @@ class RouterAgent:
         return False
 
     def _generate_test_cases(self, issue_id: str, question: str, **kwargs: Any) -> str:
-        """Return test cases string generated from Jira ``issue_id``."""
+        """Return test cases string generated from Jira ``issue_id``.
+
+        ``None`` is returned when test cases are already present on the issue.
+        """
         try:
             issue_json = get_issue_by_id_tool.run(issue_id)
             issue = json.loads(issue_json)


### PR DESCRIPTION
## Summary
- document that `_generate_test_cases` can return `None` if tests exist

## Testing
- `pytest -q` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_684978559bdc8328b0c0fae42226e355