### PR TITLE
Fix test-case prompts to include summary

### DIFF
--- a/src/prompts/tests/delete_test_cases.txt
+++ b/src/prompts/tests/delete_test_cases.txt
@@ -8,11 +8,13 @@ Make them generic enough for any DELETE endpoint before implementation exists:
 - **Test Case 1: Success Path** — valid request returns 204 or 200 with confirmation.
 - **Test Case 2: Not Found** — deleting a missing resource returns 404.
 
-If the summary includes a DELETE URL (e.g. `DELETE: people/v1/experts`), use it in the `Endpoint URL` field. 
+If the summary includes a DELETE URL (e.g. `DELETE: people/v1/experts`), use it in the `Endpoint URL` field.
 If the summary does not provide enough details to create meaningful tests, reply with:
 "Not enough information to generate test cases."
 
-  Output your answer as Markdown following exatly below example. Do not create multiple steps.Do not add '''json to the response. 
+Summary: {summary}
+
+  Output your answer as Markdown following exatly below example. Do not create multiple steps.Do not add '''json to the response.
 ```markdown
 **Test Case 1: Success - Delete Resource**
 

--- a/src/prompts/tests/get_test_cases.txt
+++ b/src/prompts/tests/get_test_cases.txt
@@ -8,11 +8,13 @@ Make them generic enough to apply to any GET endpoint before any implementation 
 - **Test Case 1: Success Path** — valid request returns 200 and correct payload.
 - **Test Case 2: Client Error** — malformed or missing parameters returns 400 with an error message.
 
-If the summary includes a GET URL (e.g. `GET: people/v1/experts`), use it in the `Endpoint URL` field. 
+If the summary includes a GET URL (e.g. `GET: people/v1/experts`), use it in the `Endpoint URL` field.
 If the summary does not provide enough details to create meaningful tests, reply with:
 "Not enough information to generate test cases."
 
-  Output your answer as Markdown following exatly below example. Do not create multiple steps.Do not add '''json to the response. 
+Summary: {summary}
+
+  Output your answer as Markdown following exatly below example. Do not create multiple steps.Do not add '''json to the response.
 Markdown array of objects, for example:
 ```markdown
 **Test Case 1: Success - Retrieve Resource**

--- a/src/prompts/tests/post_test_cases.txt
+++ b/src/prompts/tests/post_test_cases.txt
@@ -10,11 +10,13 @@
   - **Test Case 1: Success Path** — valid body returns 201 with created resource.
   - **Test Case 2: Client Error** — missing or invalid fields returns 400 with an error message.
 
-  If the summary includes a POST URL (e.g. `POST: people/v1/experts`), use it in the `Endpoint URL` field. 
+  If the summary includes a POST URL (e.g. `POST: people/v1/experts`), use it in the `Endpoint URL` field.
   If the summary does not provide enough details to create meaningful tests, reply with:
   "Not enough information to generate test cases."
 
-  Output your answer as Markdown following exatly below example. Do not create multiple steps.Do not add '''json to the response. 
+Summary: {summary}
+
+  Output your answer as Markdown following exatly below example. Do not create multiple steps.Do not add '''json to the response.
   ```markdown
   **Test Case 1: Success - Create Resource**
 

--- a/src/prompts/tests/put_test_cases.txt
+++ b/src/prompts/tests/put_test_cases.txt
@@ -8,11 +8,13 @@ Make them generic enough for any PUT endpoint before implementation exists:
 - **Test Case 1: Success Path** — valid update returns 200 with updated resource.
 - **Test Case 2: Not Found** — updating a missing resource returns 404.
 
-If the summary includes a PUT URL (e.g. `PUT: people/v1/experts`), use it in the `Endpoint URL` field. 
+If the summary includes a PUT URL (e.g. `PUT: people/v1/experts`), use it in the `Endpoint URL` field.
 If the summary does not provide enough details to create meaningful tests, reply with:
 "Not enough information to generate test cases."
 
-  Output your answer as Markdown following exatly below example. Do not create multiple steps.Do not add '''json to the response. 
+Summary: {summary}
+
+  Output your answer as Markdown following exatly below example. Do not create multiple steps.Do not add '''json to the response.
 ```markdown
 **Test Case 1: Success - Update Resource**
 

--- a/src/prompts/tests/testCasesGeneration.txt
+++ b/src/prompts/tests/testCasesGeneration.txt
@@ -12,6 +12,8 @@ Make them generic enough to apply to any GET endpoint before any implementation 
 If the summary does not provide enough details to create meaningful tests, reply with:
 "Not enough information to generate test cases."
 
+Summary: {summary}
+
 Output your answer as a JSON array of objects, for example:
 ```
 [


### PR DESCRIPTION
## Summary
- include `Summary: {summary}` in POST, GET, PUT, DELETE, and default test case prompts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6849a00bd2148328b1c71ed0b818e4f5