### PR TITLE
Decouple test generation from validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The `/ask` endpoint accepts a JSON payload containing a `question` field and ret
 
 ### Test Case Generation
 
-Ask the assistant for test cases and it will validate the Jira issue before trying to generate them. The generation step first checks the description for existing tests and returns `HAS_TESTS` when they are found. The planning pipeline detects the HTTP method and selects the matching prompt for generating tests. If the method cannot be identified, the default prompt is used. If the ticket lacks enough details the assistant will reply "Not enough information to generate test cases." otherwise it returns basic scenarios.
+Ask the assistant for test cases and it will attempt to generate them directly. Validation can be run separately if needed. The generation step first checks the description for existing tests and returns `HAS_TESTS` when they are found. The planning pipeline detects the HTTP method and selects the matching prompt for generating tests. If the method cannot be identified, the default prompt is used. If the ticket lacks enough details the assistant will reply "Not enough information to generate test cases." otherwise it returns basic scenarios.
 
 When tests are successfully generated they are appended to the end of the issue's
 **Description** field using the Jira API.

--- a/src/agents/router_agent.py
+++ b/src/agents/router_agent.py
@@ -262,9 +262,8 @@ class RouterAgent:
             logger.exception("Failed to update description for %s", issue_id)
             return False
 
-    def _validate_and_generate_tests(self, issue_id: str, question: str, **kwargs: Any) -> str:
-        """Run validation and return generated test cases if possible."""
-        self._classify_and_validate(issue_id, **kwargs)
+    def _generate_tests(self, issue_id: str, question: str, **kwargs: Any) -> str:
+        """Return generated test cases and update Jira when possible."""
         tests = self._generate_test_cases(issue_id, question, **kwargs)
         cleaned = normalize_newlines(tests)
         if cleaned and not cleaned.lower().startswith("not enough"):
@@ -328,15 +327,9 @@ class RouterAgent:
                     comment_posted = self._handle_validation_result(issue_id, answer)
                     if comment_posted:
                         answer += "\n\nValidation summary posted as a Jira comment."
-                    tests = self._generate_test_cases(issue_id, question, **kwargs)
-                    if tests:
-                        cleaned = normalize_newlines(tests)
-                        if not cleaned.lower().startswith("not enough") and self._add_tests_to_description(issue_id, cleaned):
-                            answer += "\n\nDescription updated with generated tests."
-                        answer += "\n\n" + cleaned
                 elif intent.startswith("TEST"):
                     logger.info("Routing to test generation workflow")
-                    answer = self._validate_and_generate_tests(issue_id, question, **kwargs)
+                    answer = self._generate_tests(issue_id, question, **kwargs)
                 else:
                     logger.info("Routing to general insights workflow")
                     include_history = self._needs_history(question, **kwargs)


### PR DESCRIPTION
## Summary
- separate test case generation from validation workflow
- update docs about generating test cases directly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6849a07c78848328815b655a34fe0a74