### PR TITLE
Fix test generation prompt

### DIFF
--- a/src/prompts/tests/delete_test_cases.txt
+++ b/src/prompts/tests/delete_test_cases.txt
@@ -9,8 +9,7 @@ Make them generic enough for any DELETE endpoint before implementation exists:
 - **Test Case 2: Not Found** — deleting a missing resource returns 404.
 
 If the summary includes a DELETE URL (e.g. `DELETE: people/v1/experts`), use it in the `Endpoint URL` field.
-If the summary does not provide enough details to create meaningful tests, reply with:
-"Not enough information to generate test cases."
+If the summary lacks details, still generate the generic test cases described above.
 
 Summary: {summary}
 

--- a/src/prompts/tests/get_test_cases.txt
+++ b/src/prompts/tests/get_test_cases.txt
@@ -9,8 +9,7 @@ Make them generic enough to apply to any GET endpoint before any implementation 
 - **Test Case 2: Client Error** — malformed or missing parameters returns 400 with an error message.
 
 If the summary includes a GET URL (e.g. `GET: people/v1/experts`), use it in the `Endpoint URL` field.
-If the summary does not provide enough details to create meaningful tests, reply with:
-"Not enough information to generate test cases."
+If the summary lacks details, still generate the generic test cases described above.
 
 Summary: {summary}
 

--- a/src/prompts/tests/post_test_cases.txt
+++ b/src/prompts/tests/post_test_cases.txt
@@ -10,9 +10,8 @@
   - **Test Case 1: Success Path** — valid body returns 201 with created resource.
   - **Test Case 2: Client Error** — missing or invalid fields returns 400 with an error message.
 
-  If the summary includes a POST URL (e.g. `POST: people/v1/experts`), use it in the `Endpoint URL` field.
-  If the summary does not provide enough details to create meaningful tests, reply with:
-  "Not enough information to generate test cases."
+If the summary includes a POST URL (e.g. `POST: people/v1/experts`), use it in the `Endpoint URL` field.
+If the summary lacks details, still generate the generic test cases using the information above.
 
 Summary: {summary}
 

--- a/src/prompts/tests/put_test_cases.txt
+++ b/src/prompts/tests/put_test_cases.txt
@@ -9,8 +9,7 @@ Make them generic enough for any PUT endpoint before implementation exists:
 - **Test Case 2: Not Found** — updating a missing resource returns 404.
 
 If the summary includes a PUT URL (e.g. `PUT: people/v1/experts`), use it in the `Endpoint URL` field.
-If the summary does not provide enough details to create meaningful tests, reply with:
-"Not enough information to generate test cases."
+If the summary lacks details, still generate the generic test cases described above.
 
 Summary: {summary}
 

--- a/src/prompts/tests/testCasesGeneration.txt
+++ b/src/prompts/tests/testCasesGeneration.txt
@@ -9,8 +9,7 @@ Make them generic enough to apply to any GET endpoint before any implementation 
 - **Test Case 2: Client Error** — malformed or missing parameters returns 400 with an error message.
 - **Test Case 3: Other Error** — non-existent resource or server fault returns an appropriate error code (e.g. 404 or 500).
 
-If the summary does not provide enough details to create meaningful tests, reply with:
-"Not enough information to generate test cases."
+If the summary lacks details, still generate the generic test cases described above.
 
 Summary: {summary}
 


### PR DESCRIPTION
## Summary
- tweak test case prompts to always generate tests when the summary has little detail

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6849b8dee1688328a52bd3070a5b08a9