### PR TITLE
Fix React agent compatibility with LangChain

### DIFF
--- a/src/agents/test_agent.py
+++ b/src/agents/test_agent.py
@@ -120,7 +120,7 @@ class TestAgent:
                 self.react_agent = initialize_agent(
                     tools=self.tools,
                     llm=self.llm,
-                    agent=AgentType.REACT_DESCRIPTION,
+                    agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
                     verbose=True,
                 )
 


### PR DESCRIPTION
## Summary
- use `ZERO_SHOT_REACT_DESCRIPTION` directly for the ReAct agent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684bd2d869b08328b0edbecc83cb53aa