### PR TITLE
Fix truncated intent classification prompt

### DIFF
--- a/src/prompts/intent_classifier.txt
+++ b/src/prompts/intent_classifier.txt
@@ -31,4 +31,5 @@ You are a Jira assistant whose job is to classify each user request into exactly
 - Question: “Create a new story for the user-profile page.” → CREATE  
 - Question: “How do I configure my IDE?” → UNKNOWN  
 
-Respond with just one of:  
+Respond with just one of:
+"VALIDATE", "OPERATE", "INSIGHT", "TEST", "CREATE" or "UNKNOWN".


### PR DESCRIPTION
## Summary
- repair the last line of `intent_classifier.txt`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685158d5987c83289260b1302b96e95a