### PR TITLE
Improve Jira transition workflow

### DIFF
--- a/src/prompts/transition_choice.txt
+++ b/src/prompts/transition_choice.txt
@@ -1,0 +1,4 @@
+You are selecting a Jira workflow transition.
+User requested: {requested}
+Available transitions: {options}
+Return only the best matching transition name. If none are suitable, respond with NONE.


### PR DESCRIPTION
## Summary
- add new prompt for selecting best workflow transition
- let JiraOperationsAgent pick transitions with help from LLM when fuzzy match fails
- simplify transition selection logic and ask user when no status matches

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6852b98d77488328a3eebfcb6b293890