### PR TITLE
Avoid full ticket output when logging disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The assistant also remembers the last Jira key you referenced. Follow-up questio
 Set `strip_unused_jira_data: true` in the config to remove avatar URLs and ID fields from Jira payloads for more concise outputs.
 Set `follow_related_jiras: true` to automatically fetch and summarize linked issues and subtasks when answering questions. Comments from those related tickets are also retrieved so important context isn't missed.
 Set `ask_for_confirmation: true` to require a confirmation prompt before any changes are made in Jira, including creating issues, updating fields and posting comments.
-Set `log_jira_payloads: false` to disable logging raw Jira API payloads returned by the tools.
+Set `log_jira_payloads: false` to disable logging raw Jira API payloads returned by the tools. When disabled, some tools such as `transition_issue` return only minimal data to avoid large debug logs.
 
 ### Debug Logging
 

--- a/src/services/jira_service.py
+++ b/src/services/jira_service.py
@@ -359,8 +359,16 @@ def transition_issue_func(issue_id: str, transition: str) -> str:
     cfg = load_config()
     if cfg.log_jira_payloads:
         logger.debug("Transition payload: %s", updated)
+        result = updated
+    else:
+        status = (
+            updated.get("fields", {})
+            .get("status", {})
+            .get("name", "")
+        )
+        result = {"key": updated.get("key", issue_id), "status": status}
     logger.info("Transitioned %s using %s", issue_id, transition)
-    return json.dumps(updated)
+    return json.dumps(result)
 
 
 def _transition_issue_wrapper(*args: str) -> str:


### PR DESCRIPTION
## Summary
- show only minimal transition result when `log_jira_payloads` is false
- document the reduced output in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6852c21cc1bc83288b3f7c13893b93b6