### PR TITLE
Implement multi-step planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,13 @@ print(result)
 When used with the `RouterAgent` any request starting with "create" is
 classified with the `CREATE` intent and routed through this agent.
 
+### Multi-step Operations
+
+The `PlanningAgent` can break down a request into multiple Jira actions. For
+example asking to add a comment and then move the ticket will produce a plan
+containing both steps. The router executes each step in order and reports which
+actions succeeded or failed.
+
 ### Error Handling
 
 The assistant now catches common issues such as invalid Jira keys or failures

--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -15,6 +15,7 @@ from .jira_operations import JiraOperationsAgent
 from .router_agent import RouterAgent
 from .test_agent import TestAgent
 from .issue_creator import IssueCreatorAgent
+from .planning import PlanningAgent
 
 __all__ = [
     "ClassifierAgent",
@@ -24,5 +25,5 @@ __all__ = [
     "RouterAgent",
     "TestAgent",
     "IssueCreatorAgent",
+    "PlanningAgent",
 ]
-

--- a/src/prompts/operations_plan.txt
+++ b/src/prompts/operations_plan.txt
@@ -1,0 +1,7 @@
+You are a planning assistant that converts a user's request into a sequence of steps for working with Jira issues.
+Respond only with JSON containing these fields:
+- issue_key: the Jira issue key the steps apply to. Use the provided context if the request doesn't specify one.
+- plan: an ordered list of steps. Each step has "agent", "action" and optional "parameters".
+Use "jira_operations" for actions like add_comment or transition_issue.
+User request: {user_request}
+Issue context: {issue_context}


### PR DESCRIPTION
## Summary
- add PlanningAgent for creating multi-step Jira plans
- move planning pipeline for tests into TestAgent
- support execution of multi-step plans in RouterAgent
- document multi-step operations capability

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6852c44546208328bbc576ddecb1635e