### PR TITLE
Fix transition success message

### DIFF
--- a/src/agents/jira_operations.py
+++ b/src/agents/jira_operations.py
@@ -207,7 +207,7 @@ class JiraOperationsAgent:
             ]
             logger.warning("Transition '%s' not available for %s", transition, issue_id)
             message = (
-                f"Transition '{transition}' is not available for {issue_id}. "
+                f"Error: Transition '{transition}' is not available for {issue_id}. "
                 f"Available statuses: {', '.join(available)}. "
             )
             if suggestion:


### PR DESCRIPTION
## Summary
- return error text when transition status not available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6852e60dd1a883288920a6a73d61f387