### PR TITLE
Add BaseAgent for shared init

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -8,6 +8,7 @@ logger.info(
     "ClassifierAgent, ApiValidatorAgent and IssueInsightsAgent will be exported"
 )
 
+from .base import BaseAgent
 from .classifier import ClassifierAgent
 from .api_validator import ApiValidatorAgent
 from .issue_insights import IssueInsightsAgent
@@ -18,6 +19,7 @@ from .issue_creator import IssueCreatorAgent
 from .planning import PlanningAgent
 
 __all__ = [
+    "BaseAgent",
     "ClassifierAgent",
     "ApiValidatorAgent",
     "IssueInsightsAgent",

--- a/src/agents/api_validator.py
+++ b/src/agents/api_validator.py
@@ -9,8 +9,7 @@ from pathlib import Path
 
 from src.prompts import load_prompt, PROMPTS_DIR
 from src.utils import extract_plain_text, safe_format
-from src.configs.config import load_config
-from src.llm_clients import create_llm_client
+from src.agents.base import BaseAgent
 
 logger = logging.getLogger(__name__)
 logger.debug("api_validator module loaded")
@@ -34,13 +33,12 @@ def _load_status_prompts(directory: str) -> Dict[str, str]:
 
 
 
-class ApiValidatorAgent:
+class ApiValidatorAgent(BaseAgent):
     """Agent that validates Jira issues based on their status."""
 
     def __init__(self, config_path: str | None = None) -> None:
         logger.debug("Initializing ApiValidatorAgent with config_path=%s", config_path)
-        self.config = load_config(config_path)
-        self.client = create_llm_client(config_path)
+        super().__init__(config_path)
 
         self.prompts = _load_status_prompts(self.config.validation_prompts_dir)
         self.general_prompt = load_prompt(

--- a/src/agents/base.py
+++ b/src/agents/base.py
@@ -1,0 +1,30 @@
+"""Base agent class providing shared configuration and LLM client setup."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from src.configs.config import load_config
+from src.llm_clients import create_llm_client
+
+logger = logging.getLogger(__name__)
+logger.debug("base agent module loaded")
+
+
+class BaseAgent:
+    """Base agent that loads configuration and initializes an LLM client."""
+
+    def __init__(self, config_path: str | None = None) -> None:
+        logger.debug("Initializing %s with config_path=%s", self.__class__.__name__, config_path)
+        self.config = load_config(config_path)
+        self.client = create_llm_client(config_path)
+
+    def ask(self, prompt: str, **kwargs: Any) -> str:
+        """Return the LLM response text for ``prompt``."""
+        messages = [{"role": "user", "content": prompt}]
+        response = self.client.chat_completion(messages, **kwargs)
+        return self.client.extract_text(response)
+
+
+__all__ = ["BaseAgent"]

--- a/src/agents/classifier.py
+++ b/src/agents/classifier.py
@@ -3,21 +3,19 @@
 from typing import List, Dict, Any
 import logging
 
-from src.configs.config import load_config
-from src.llm_clients import create_llm_client
+from src.agents.base import BaseAgent
 from src.services.jira_service import get_issue_by_id_tool
 
 logger = logging.getLogger(__name__)
 logger.debug("classifier module loaded")
 
 
-class ClassifierAgent:
+class ClassifierAgent(BaseAgent):
     """Agent that selects an LLM client based on configuration."""
 
     def __init__(self, config_path: str | None = None) -> None:
         logger.debug("Initializing ClassifierAgent with config_path=%s", config_path)
-        self.config = load_config(config_path)
-        self.client = create_llm_client(config_path)
+        super().__init__(config_path)
 
         # Tools available to this agent
         self.tools = [get_issue_by_id_tool]

--- a/src/agents/issue_creator.py
+++ b/src/agents/issue_creator.py
@@ -7,8 +7,7 @@ import logging
 from typing import Any
 
 from src.agents.jira_operations import JiraOperationsAgent
-from src.configs.config import load_config
-from src.llm_clients import create_llm_client
+from src.agents.base import BaseAgent
 from src.prompts import load_prompt
 from src.utils import safe_format, parse_json_block
 
@@ -16,13 +15,12 @@ logger = logging.getLogger(__name__)
 logger.debug("issue_creator module loaded")
 
 
-class IssueCreatorAgent:
+class IssueCreatorAgent(BaseAgent):
     """Agent that extracts issue details and creates Jira tickets."""
 
     def __init__(self, config_path: str | None = None) -> None:
         logger.debug("Initializing IssueCreatorAgent with config_path=%s", config_path)
-        self.config = load_config(config_path)
-        self.client = create_llm_client(config_path)
+        super().__init__(config_path)
         self.operations = JiraOperationsAgent(config_path)
         self.plan_prompt = load_prompt("issue_plan.txt")
 

--- a/src/agents/issue_insights.py
+++ b/src/agents/issue_insights.py
@@ -7,8 +7,7 @@ import logging
 from typing import Any, Dict
 from datetime import datetime
 
-from src.configs.config import load_config
-from src.llm_clients import create_llm_client
+from src.agents.base import BaseAgent
 from src.prompts import load_prompt
 from src.utils import safe_format
 from src.services.jira_service import (
@@ -22,13 +21,12 @@ logger = logging.getLogger(__name__)
 logger.debug("issue_insights module loaded")
 
 
-class IssueInsightsAgent:
+class IssueInsightsAgent(BaseAgent):
     """Agent that answers general questions about Jira issues."""
 
     def __init__(self, config_path: str | None = None) -> None:
         logger.debug("Initializing IssueInsightsAgent with config_path=%s", config_path)
-        self.config = load_config(config_path)
-        self.client = create_llm_client(config_path)
+        super().__init__(config_path)
 
         # Tools available to this agent
         self.tools = [get_issue_by_id_tool, get_issue_history_tool]

--- a/src/agents/jira_operations.py
+++ b/src/agents/jira_operations.py
@@ -15,8 +15,7 @@ from src.services.jira_service import (
     transition_issue_tool,
 )
 from src.agents.issue_insights import IssueInsightsAgent
-from src.configs.config import load_config
-from src.llm_clients import create_llm_client
+from src.agents.base import BaseAgent
 from src.prompts import load_prompt
 from src.utils import safe_format, parse_json_block
 
@@ -24,15 +23,14 @@ logger = logging.getLogger(__name__)
 logger.debug("jira_operations module loaded")
 
 
-class JiraOperationsAgent:
+class JiraOperationsAgent(BaseAgent):
     """Agent that performs modifications on Jira issues."""
 
     def __init__(self, config_path: str | None = None) -> None:
         logger.debug(
             "Initializing JiraOperationsAgent with config_path=%s", config_path
         )
-        self.config = load_config(config_path)
-        self.client = create_llm_client(config_path)
+        super().__init__(config_path)
         self.insights = IssueInsightsAgent(config_path)
 
         # Tools available to this agent

--- a/src/agents/planning.py
+++ b/src/agents/planning.py
@@ -6,8 +6,7 @@ import json
 import logging
 from typing import Any, Dict
 
-from src.configs.config import load_config
-from src.llm_clients import create_llm_client
+from src.agents.base import BaseAgent
 from src.prompts import load_prompt
 from src.utils import safe_format, parse_json_block
 
@@ -15,13 +14,12 @@ logger = logging.getLogger(__name__)
 logger.debug("planning module loaded")
 
 
-class PlanningAgent:
+class PlanningAgent(BaseAgent):
     """Generate a structured execution plan for Jira operations."""
 
     def __init__(self, config_path: str | None = None) -> None:
         logger.debug("Initializing PlanningAgent with config_path=%s", config_path)
-        self.config = load_config(config_path)
-        self.client = create_llm_client(config_path)
+        super().__init__(config_path)
         self.plan_prompt = load_prompt("operations_plan.txt")
 
     def generate_plan(

--- a/src/agents/router_agent.py
+++ b/src/agents/router_agent.py
@@ -25,7 +25,7 @@ except Exception:  # pragma: no cover - optional dependency
     CombinedMemory = None
     ChatOpenAI = None
 
-from src.configs.config import load_config
+from src.agents.base import BaseAgent
 from src.agents.classifier import ClassifierAgent
 from src.agents.issue_insights import IssueInsightsAgent
 from src.agents.api_validator import ApiValidatorAgent
@@ -49,12 +49,12 @@ logger = logging.getLogger(__name__)
 logger.debug("router_agent module loaded")
 
 
-class RouterAgent:
+class RouterAgent(BaseAgent):
     """Agent that routes questions to insights or validation workflows."""
 
     def __init__(self, config_path: str | None = None) -> None:
         logger.debug("Initializing RouterAgent with config_path=%s", config_path)
-        self.config = load_config(config_path)
+        super().__init__(config_path)
         self.classifier = ClassifierAgent(config_path)
         self.validator = ApiValidatorAgent(config_path)
         self.insights = IssueInsightsAgent(config_path)

--- a/src/agents/test_agent.py
+++ b/src/agents/test_agent.py
@@ -12,8 +12,8 @@ from typing import Any, Dict, Optional
 import json
 import re
 
-from src.configs.config import load_config
-from src.llm_clients import create_llm_client, create_langchain_llm
+from src.agents.base import BaseAgent
+from src.llm_clients import create_langchain_llm
 from src.prompts import load_prompt
 from src.utils import safe_format
 
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 logger.debug("test_agent module loaded")
 
 
-class TestAgent:
+class TestAgent(BaseAgent):
     """Agent that generates test cases from freeform text.
 
     The text can be a validation summary, the Jira issue description or any
@@ -49,8 +49,7 @@ class TestAgent:
 
     def __init__(self, config_path: str | None = None) -> None:
         logger.debug("Initializing TestAgent with config_path=%s", config_path)
-        self.config = load_config(config_path)
-        self.client = create_llm_client(config_path)
+        super().__init__(config_path)
         self.prompts = {
             "GET": load_prompt("tests/get_test_cases.txt"),
             "POST": load_prompt("tests/post_test_cases.txt"),


### PR DESCRIPTION
## Summary
- create `BaseAgent` for shared configuration and LLM client setup
- update all agents to inherit from `BaseAgent`
- re-export `BaseAgent` from the agents package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685403e4de2483289b73dd8333a09c05