### PR TITLE
Improve follow-up prompts

### DIFF
--- a/src/agents/issue_creator.py
+++ b/src/agents/issue_creator.py
@@ -52,7 +52,7 @@ class IssueCreatorAgent:
             issue_type_norm = "Sub-task"
         parent = plan.get("parent")
         if issue_type_norm == "Sub-task" and not parent:
-            return "Parent issue key is required for sub-tasks"
+            return "Sure, I can create a sub-task. Which parent issue should it be under?"
         result = self.operations.create_issue(
             summary,
             description,

--- a/src/agents/router_agent.py
+++ b/src/agents/router_agent.py
@@ -288,7 +288,7 @@ class RouterAgent:
         """Return generated test cases and update Jira when possible."""
         tests = self._generate_test_cases(issue_id, question, **kwargs)
         if tests is None:
-            return "It looks like this issue already has test cases."
+            return "This issue already has test cases."
 
         cleaned = normalize_newlines(tests)
         if cleaned and not cleaned.lower().startswith("not enough"):


### PR DESCRIPTION
## Summary
- ask for the parent issue when missing from a sub-task request
- return a clearer response when test cases already exist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685406e75bc08328ada3a377ee31d28c