### PR TITLE
Implement automatic session reset without LangChain memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ LOG_JIRA_PAYLOADS=true
 The default model and provider can be changed in `src/configs/config.yml` or by setting `OPENAI_MODEL` and `BASE_LLM` in the environment. The flag `INCLUDE_WHOLE_API_BODY` controls whether validation prompts should return the full API bodies or only boolean indicators of their validity.
 
 
-Conversation memory can be enabled with `conversation_memory: true` in the same file. The number of previous questions remembered defaults to three and can be adjusted via `max_questions_to_remember`. When LangChain is available the agent uses a `ConversationBufferWindowMemory` of size `k`. If `k` is greater than three the buffer is combined with `ConversationSummaryMemory` so older turns are summarized automatically. When the limit is reached you'll be prompted to start a new conversation.
+Conversation memory can be enabled with `conversation_memory: true` in the same file. The number of previous questions remembered defaults to three and can be adjusted via `max_questions_to_remember`. When LangChain is available the agent uses a `ConversationBufferWindowMemory` of size `k`. If `k` is greater than three the buffer is combined with `ConversationSummaryMemory` so older turns are summarized automatically. When the limit is reached you'll be prompted to start a new conversation. If LangChain is not installed or memory is disabled the session is cleared automatically once the limit is reached and a short notice is returned before the answer.
 
 The assistant also remembers the last Jira key you referenced. Follow-up questions can omit the key and it will use the stored value. Include the word `forget` in your message to clear this memory.
 


### PR DESCRIPTION
## Summary
- auto clear chat history when conversation exceeds `max_questions_to_remember`
- inform the user when the session has been reset
- document fallback behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6854074085348328aa18d7f5d66c428b