### PR TITLE
Add conversation history support across agents

### DIFF
--- a/src/agents/test_agent.py
+++ b/src/agents/test_agent.py
@@ -146,7 +146,7 @@ class TestAgent:
         return match.group(1).upper() if match else None
 
     def create_test_cases(
-        self, text: str, method: Optional[str] = None, **kwargs: Any
+        self, text: str, method: Optional[str] = None, history: str = "", **kwargs: Any
     ) -> str:
         """Return generated test cases or a message when they already exist.
 
@@ -155,6 +155,9 @@ class TestAgent:
         short explanatory message. Otherwise the response contains the new
         tests which are returned as-is.
         """
+
+        if history:
+            text = f"Previous conversation:\n{history}\n\nCurrent test request:\n{text}"
 
         if None not in (
             self.llm,


### PR DESCRIPTION
## Summary
- support injecting conversation history into ApiValidatorAgent
- add history-aware test case generation
- improve Jira operations planning with prior conversation context
- allow IssueCreatorAgent to use previous chat history
- enhance RouterAgent to forward context to sub-agents and classify intents using history
- expose `max_context_turns` and `enable_global_memory` config options
- simplify memory config usage
- refactor conversation history retrieval

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68541e630c9883289d5fa7594bdf4f6b