### PR TITLE
Add shared JiraContextMemory to agents

### DIFF
--- a/src/agents/api_validator.py
+++ b/src/agents/api_validator.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from pathlib import Path
 
 from src.prompts import load_prompt, PROMPTS_DIR
-from src.utils import extract_plain_text, safe_format
+from src.utils import extract_plain_text, safe_format, JiraContextMemory
 from src.configs.config import load_config
 from src.llm_clients import create_llm_client
 
@@ -37,10 +37,17 @@ def _load_status_prompts(directory: str) -> Dict[str, str]:
 class ApiValidatorAgent:
     """Agent that validates Jira issues based on their status."""
 
-    def __init__(self, config_path: str | None = None) -> None:
-        logger.debug("Initializing ApiValidatorAgent with config_path=%s", config_path)
+    def __init__(
+        self,
+        config_path: str | None = None,
+        memory: Optional[JiraContextMemory] = None,
+    ) -> None:
+        logger.debug(
+            "Initializing ApiValidatorAgent with config_path=%s", config_path
+        )
         self.config = load_config(config_path)
         self.client = create_llm_client(config_path)
+        self.memory = memory
 
         self.prompts = _load_status_prompts(self.config.validation_prompts_dir)
         self.general_prompt = load_prompt(

--- a/src/agents/classifier.py
+++ b/src/agents/classifier.py
@@ -1,11 +1,12 @@
 """Simple classifier agent using a configurable LLM provider."""
 
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 import logging
 
 from src.configs.config import load_config
 from src.llm_clients import create_llm_client
 from src.services.jira_service import get_issue_by_id_tool
+from src.utils import JiraContextMemory
 
 logger = logging.getLogger(__name__)
 logger.debug("classifier module loaded")
@@ -14,10 +15,17 @@ logger.debug("classifier module loaded")
 class ClassifierAgent:
     """Agent that selects an LLM client based on configuration."""
 
-    def __init__(self, config_path: str | None = None) -> None:
-        logger.debug("Initializing ClassifierAgent with config_path=%s", config_path)
+    def __init__(
+        self,
+        config_path: str | None = None,
+        memory: Optional[JiraContextMemory] = None,
+    ) -> None:
+        logger.debug(
+            "Initializing ClassifierAgent with config_path=%s", config_path
+        )
         self.config = load_config(config_path)
         self.client = create_llm_client(config_path)
+        self.memory = memory
 
         # Tools available to this agent
         self.tools = [get_issue_by_id_tool]

--- a/src/agents/issue_creator.py
+++ b/src/agents/issue_creator.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from src.agents.jira_operations import JiraOperationsAgent
 from src.configs.config import load_config
 from src.llm_clients import create_llm_client
 from src.prompts import load_prompt
-from src.utils import safe_format, parse_json_block
+from src.utils import safe_format, parse_json_block, JiraContextMemory
 
 logger = logging.getLogger(__name__)
 logger.debug("issue_creator module loaded")
@@ -19,11 +19,18 @@ logger.debug("issue_creator module loaded")
 class IssueCreatorAgent:
     """Agent that extracts issue details and creates Jira tickets."""
 
-    def __init__(self, config_path: str | None = None) -> None:
-        logger.debug("Initializing IssueCreatorAgent with config_path=%s", config_path)
+    def __init__(
+        self,
+        config_path: str | None = None,
+        memory: Optional[JiraContextMemory] = None,
+    ) -> None:
+        logger.debug(
+            "Initializing IssueCreatorAgent with config_path=%s", config_path
+        )
         self.config = load_config(config_path)
         self.client = create_llm_client(config_path)
-        self.operations = JiraOperationsAgent(config_path)
+        self.memory = memory
+        self.operations = JiraOperationsAgent(config_path, memory=memory)
         self.plan_prompt = load_prompt("issue_plan.txt")
 
     def plan_issue(self, request: str, history: str = "", **kwargs: Any) -> dict[str, Any]:

--- a/src/agents/issue_insights.py
+++ b/src/agents/issue_insights.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 from datetime import datetime
 
 from src.configs.config import load_config
 from src.llm_clients import create_llm_client
 from src.prompts import load_prompt
-from src.utils import safe_format
+from src.utils import safe_format, JiraContextMemory
 from src.services.jira_service import (
     get_issue_by_id_tool,
     get_issue_history_tool,
@@ -25,10 +25,17 @@ logger.debug("issue_insights module loaded")
 class IssueInsightsAgent:
     """Agent that answers general questions about Jira issues."""
 
-    def __init__(self, config_path: str | None = None) -> None:
-        logger.debug("Initializing IssueInsightsAgent with config_path=%s", config_path)
+    def __init__(
+        self,
+        config_path: str | None = None,
+        memory: Optional[JiraContextMemory] = None,
+    ) -> None:
+        logger.debug(
+            "Initializing IssueInsightsAgent with config_path=%s", config_path
+        )
         self.config = load_config(config_path)
         self.client = create_llm_client(config_path)
+        self.memory = memory
 
         # Tools available to this agent
         self.tools = [get_issue_by_id_tool, get_issue_history_tool]

--- a/src/agents/planning.py
+++ b/src/agents/planning.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from src.configs.config import load_config
 from src.llm_clients import create_llm_client
 from src.prompts import load_prompt
-from src.utils import safe_format, parse_json_block
+from src.utils import safe_format, parse_json_block, JiraContextMemory
 
 logger = logging.getLogger(__name__)
 logger.debug("planning module loaded")
@@ -18,10 +18,17 @@ logger.debug("planning module loaded")
 class PlanningAgent:
     """Generate a structured execution plan for Jira operations."""
 
-    def __init__(self, config_path: str | None = None) -> None:
-        logger.debug("Initializing PlanningAgent with config_path=%s", config_path)
+    def __init__(
+        self,
+        config_path: str | None = None,
+        memory: Optional[JiraContextMemory] = None,
+    ) -> None:
+        logger.debug(
+            "Initializing PlanningAgent with config_path=%s", config_path
+        )
         self.config = load_config(config_path)
         self.client = create_llm_client(config_path)
+        self.memory = memory
         self.plan_prompt = load_prompt("operations_plan.txt")
 
     def generate_plan(

--- a/src/agents/router_agent.py
+++ b/src/agents/router_agent.py
@@ -53,13 +53,14 @@ class RouterAgent:
     def __init__(self, config_path: str | None = None) -> None:
         logger.debug("Initializing RouterAgent with config_path=%s", config_path)
         self.config = load_config(config_path)
-        self.classifier = ClassifierAgent(config_path)
-        self.validator = ApiValidatorAgent(config_path)
-        self.insights = IssueInsightsAgent(config_path)
-        self.operations = JiraOperationsAgent(config_path)
-        self.tester = TestAgent(config_path)
-        self.creator = IssueCreatorAgent(config_path)
-        self.planner = PlanningAgent(config_path)
+        self.session_memory = JiraContextMemory()
+        self.classifier = ClassifierAgent(config_path, memory=self.session_memory)
+        self.validator = ApiValidatorAgent(config_path, memory=self.session_memory)
+        self.insights = IssueInsightsAgent(config_path, memory=self.session_memory)
+        self.operations = JiraOperationsAgent(config_path, memory=self.session_memory)
+        self.tester = TestAgent(config_path, memory=self.session_memory)
+        self.creator = IssueCreatorAgent(config_path, memory=self.session_memory)
+        self.planner = PlanningAgent(config_path, memory=self.session_memory)
         self.plan_executor = OperationsPlanExecutor(self.operations)
         self.use_memory = self.config.conversation_memory
         self.max_history = self.config.max_questions_to_remember
@@ -75,7 +76,6 @@ class RouterAgent:
                 logger.warning("LangChain not installed; conversation memory disabled")
             self.use_memory = False
             self.memory = None
-        self.session_memory = JiraContextMemory()
         if self.config.projects:
             pattern = "|".join(re.escape(p) for p in self.config.projects)
         else:

--- a/src/agents/test_agent.py
+++ b/src/agents/test_agent.py
@@ -15,7 +15,7 @@ import re
 from src.configs.config import load_config
 from src.llm_clients import create_llm_client, create_langchain_llm
 from src.prompts import load_prompt
-from src.utils import safe_format
+from src.utils import safe_format, JiraContextMemory
 
 try:
     from langchain.chains import LLMChain, SequentialChain  # type: ignore
@@ -53,10 +53,15 @@ class TestAgent:
     other contextual information combined with the user's question.
     """
 
-    def __init__(self, config_path: str | None = None) -> None:
+    def __init__(
+        self,
+        config_path: str | None = None,
+        memory: Optional[JiraContextMemory] = None,
+    ) -> None:
         logger.debug("Initializing TestAgent with config_path=%s", config_path)
         self.config = load_config(config_path)
         self.client = create_llm_client(config_path)
+        self.memory = memory
         self.prompts = {
             "GET": load_prompt("tests/get_test_cases.txt"),
             "POST": load_prompt("tests/post_test_cases.txt"),


### PR DESCRIPTION
## Summary
- refactor all agent constructors to accept optional JiraContextMemory
- store the memory reference and use it in JiraOperationsAgent
- pass RouterAgent session_memory to new agent instances

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68650536b53c8328b13f89d264224baf