### PR TITLE
Remove duplicated helper in RouterAgent

### DIFF
--- a/src/agents/router_agent.py
+++ b/src/agents/router_agent.py
@@ -190,14 +190,6 @@ class RouterAgent:
     # ------------------------------------------------------------------
     # Tooling helpers
     # ------------------------------------------------------------------
-    def _parse_tool_input(self, input_str: str) -> Dict[str, str]:
-        """Parse tool input in format 'key:value|key:value'."""
-        parts: Dict[str, str] = {}
-        for part in input_str.split("|"):
-            if ":" in part:
-                key, value = part.split(":", 1)
-                parts[key.strip()] = value.strip()
-        return parts
 
     def _create_tools(self) -> List["BaseTool"]: # type: ignore
         if Tool is None:


### PR DESCRIPTION
## Summary
- clean up duplicated `_parse_tool_input` definition in `RouterAgent`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68651abe96048328a578f3b207a4d470