### PR TITLE
Use planning for all router operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ result = creator.create_issue(
 print(result)
 ```
 
-When used with the `RouterAgent` any request starting with "create" is
-classified with the `CREATE` intent and routed through this agent.
+When used with the `RouterAgent` a request to create an issue automatically
+invokes this agent through the planning pipeline.
 
 ### Multi-step Operations
 

--- a/src/prompts/operations_plan.txt
+++ b/src/prompts/operations_plan.txt
@@ -3,7 +3,10 @@ Respond only with JSON containing these fields:
 - issue_key: the Jira issue key the steps apply to. Use the provided context if the request doesn't specify one.
 - plan: an ordered list of steps. Each step has "agent", "action" and optional "parameters".
 
-Use "jira_operations" for actions like "add_comment" or "transition_issue".
+Use "jira_operations" for actions like "add_comment", "create_issue" or "transition_issue".
+Use "api_validator" with the "validate" action when the request involves API validation.
+Use "test_agent" with action "generate_tests" to produce test cases.
+Use "issue_insights" with action "ask" for general questions about the issue.
 Steps will be executed strictly in the order provided. Later steps can refer to
 previous results using ``$stepN`` or ``$stepN.field`` where ``N`` is the 1-based
 step number.

--- a/src/utils/plan_executor.py
+++ b/src/utils/plan_executor.py
@@ -6,14 +6,25 @@ from typing import Any, Dict
 import json
 import logging
 
+from src.services.jira_service import get_issue_by_id_tool
+
 logger = logging.getLogger(__name__)
 
 
 class OperationsPlanExecutor:
     """Execute a plan of Jira operations sequentially."""
 
-    def __init__(self, operations_agent: Any) -> None:
+    def __init__(
+        self,
+        operations_agent: Any,
+        validator_agent: Any | None = None,
+        test_agent: Any | None = None,
+        insights_agent: Any | None = None,
+    ) -> None:
         self.operations = operations_agent
+        self.validator = validator_agent
+        self.tester = test_agent
+        self.insights = insights_agent
 
     def _lookup(self, value: str, results: Dict[str, Any]) -> Any:
         """Resolve "$stepN" or "$stepN.field" references."""
@@ -64,17 +75,45 @@ class OperationsPlanExecutor:
 
             logger.info("Step %d/%d: %s.%s with params %s", i, len(steps), agent, action, params)
 
-            if agent != "jira_operations":
+            if agent == "jira_operations":
+                target = self.operations
+                call_args = (issue_key,)
+            elif agent == "api_validator" and self.validator is not None:
+                target = self.validator
+                issue_json = get_issue_by_id_tool.run(issue_key)
+                try:
+                    issue_data = json.loads(issue_json)
+                except Exception:
+                    issue_data = issue_json
+                call_args = (issue_data,)
+            elif agent == "test_agent" and self.tester is not None:
+                target = self.tester
+                issue_json = get_issue_by_id_tool.run(issue_key)
+                try:
+                    issue = json.loads(issue_json)
+                except Exception:
+                    issue = {}
+                fields = issue.get("fields", {}) if isinstance(issue, dict) else {}
+                summary = fields.get("summary", "")
+                description = fields.get("description", "")
+                question = params.pop("question", "")
+                text = f"{summary}\n{description}\n{question}"
+                call_args = (text, None)
+            elif agent == "issue_insights" and self.insights is not None:
+                target = self.insights
+                question = params.pop("question", "Tell me about this issue")
+                call_args = (issue_key, question)
+            else:
                 results[step_name] = f"Unknown agent {agent}"
                 continue
 
-            func = getattr(self.operations, action, None)
+            func = getattr(target, action, None)
             if not callable(func):
                 results[step_name] = f"Unknown action {action}"
                 continue
 
             try:
-                result = func(issue_key, **params, **kwargs)
+                result = func(*call_args, **params, **kwargs)
                 results[step_name] = result
                 if isinstance(result, str) and result.startswith("Error"):
                     logger.warning("Step %d failed: %s", i, result)


### PR DESCRIPTION
## Summary
- remove intent-based helpers and classification usage
- expand operations planner to handle insights, validation and tests
- route every request through the planner
- update planning prompt and README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68652491d2408328af0d8eba0b7b6773